### PR TITLE
Fix getIdentifiable which does not fill sub objects

### DIFF
--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -5208,4 +5208,20 @@ public class NetworkStoreIT {
             assertEquals(100, twt1.getTerminal2().getP(), 0);
         }
     }
+
+    @Test
+    public void testFixNpeGetIdentifiable() {
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Network network = EurostagTutorialExample1Factory.create(service.getNetworkFactory());
+            service.flush(network);
+        }
+
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Map<UUID, String> networkIds = service.getNetworkIds();
+            UUID networkUuid = networkIds.keySet().stream().findFirst().orElseThrow();
+            Network network = service.getNetwork(networkUuid);
+            TwoWindingsTransformer twt2 = (TwoWindingsTransformer) network.getIdentifiable("NHV2_NLOAD");
+            assertEquals(2, twt2.getRatioTapChanger().getHighTapPosition());
+        }
+    }
 }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -1538,11 +1538,12 @@ public class NetworkStoreRepository {
                             bindAttributes(resultSet, columnIndex, columnMapping, attributes);
                         });
 
-                        return Optional.of(new Resource.Builder<>(tableMapping.getResourceType())
+                        Resource<IdentifiableAttributes> resource = new Resource.Builder<>(tableMapping.getResourceType())
                                 .id(id)
                                 .variantNum(variantNum)
                                 .attributes(attributes)
-                                .build());
+                                .build();
+                        return Optional.of(completeResourceInfos(resource, networkUuid, variantNum, id));
                     }
                 }
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
We get a NPE when getting for instance a transformer with a ratio tap changer with steps because when getting the idetifiable from the database we don't query complementary tables to fill sub objetcs.


**What is the new behavior (if this is a feature change)?**
The identifiable is fully loaded.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
