### PR TITLE
Remove more obsolete thrown exception assertions (same as 23e39c231)

### DIFF
--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -947,8 +947,6 @@ public class NetworkStoreIT {
             battery.setMinP(50);
             verify(mockedListener, times(1)).onUpdate(battery, "maxP", 70d, 90d);
             verify(mockedListener, times(1)).onUpdate(battery, "minP", 40d, 50d);
-
-            assertTrue(assertThrows(ValidationException.class, () -> battery.setMaxP(60)).getMessage().contains("invalid active power p > maxP"));
         }
     }
 


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**What is the current behavior?**
Using the next version of powsybl-network-store-client, integration tests in the server fail:

```
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
11:12:11.737 [main] INFO  com.powsybl.network.store.client.NetworkStoreService - Preloading strategy: NONE
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.853 s <<< FAILURE! -- in com.powsybl.network.store.integration.NetworkStoreIT
[ERROR] com.powsybl.network.store.integration.NetworkStoreIT.batteryTest -- Time elapsed: 1.645 s <<< FAILURE!
java.lang.AssertionError: expected com.powsybl.iidm.network.ValidationException to be thrown, but nothing was thrown
	at org.junit.Assert.assertThrows(Assert.java:1028)
	at org.junit.Assert.assertThrows(Assert.java:981)
	at com.powsybl.network.store.integration.NetworkStoreIT.batteryTest(NetworkStoreIT.java:951)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   NetworkStoreIT.batteryTest:951 expected com.powsybl.iidm.network.ValidationException to be thrown, but nothing was thrown
[INFO] 
```


**What is the new behavior (if this is a feature change)?**
tests pass (the assertion is just removed because it was outdated)


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
NO

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
It deprecated by the powsybl 4.7 migration but was missed in networkstore client at the time the deprecated method is removed in powsybl 6 so this becomes necessary

original client 4.7 migration: https://github.com/powsybl/powsybl-network-store/commit/23e39c23
subsequent client 4.7 migration: https://github.com/powsybl/powsybl-network-store/commit/d711d335d