### PR TITLE
Generalize extensions

### DIFF
--- a/network-store-server/pom.xml
+++ b/network-store-server/pom.xml
@@ -103,6 +103,11 @@
         <!-- runtime scope -->
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-network-store-iidm-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-config-classic</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/ExtensionHandler.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/ExtensionHandler.java
@@ -72,7 +72,7 @@ public class ExtensionHandler {
             return Collections.emptyMap();
         }
         try (var connection = dataSource.getConnection()) {
-            var preparedStmt = connection.prepareStatement(QueryExtensionCatalog.buildExtensionsWithInClauseQuery(columnNameForWhereClause, valuesForInClause.size()));
+            var preparedStmt = connection.prepareStatement(QueryExtensionCatalog.buildGetExtensionsWithInClauseQuery(columnNameForWhereClause, valuesForInClause.size()));
             preparedStmt.setObject(1, networkUuid);
             preparedStmt.setInt(2, variantNum);
             for (int i = 0; i < valuesForInClause.size(); i++) {
@@ -87,7 +87,7 @@ public class ExtensionHandler {
 
     public Map<OwnerInfo, Map<String, ExtensionAttributes>> getExtensions(UUID networkUuid, int variantNum, String columnNameForWhereClause, String valueForWhereClause) {
         try (var connection = dataSource.getConnection()) {
-            var preparedStmt = connection.prepareStatement(QueryExtensionCatalog.buildExtensionsQuery(columnNameForWhereClause));
+            var preparedStmt = connection.prepareStatement(QueryExtensionCatalog.buildGetExtensionsQuery(columnNameForWhereClause));
             preparedStmt.setObject(1, networkUuid);
             preparedStmt.setInt(2, variantNum);
             preparedStmt.setString(3, valueForWhereClause);

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/ExtensionHandler.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/ExtensionHandler.java
@@ -1,0 +1,203 @@
+package com.powsybl.network.store.server;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.powsybl.network.store.model.ExtensionAttributes;
+import com.powsybl.network.store.model.IdentifiableAttributes;
+import com.powsybl.network.store.model.Resource;
+import com.powsybl.network.store.model.ResourceType;
+import com.powsybl.network.store.server.dto.OwnerInfo;
+import com.powsybl.network.store.server.exceptions.UncheckedSqlException;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+import static com.powsybl.network.store.server.NetworkStoreRepository.BATCH_SIZE;
+import static com.powsybl.network.store.server.Utils.bindValues;
+
+@Component
+public class ExtensionHandler {
+    private final DataSource dataSource;
+    private final ObjectMapper mapper;
+
+    public ExtensionHandler(DataSource dataSource, ObjectMapper mapper) {
+        this.dataSource = dataSource;
+        this.mapper = mapper.enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature());
+    }
+
+    public void insertExtensions(Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions) {
+        try (var connection = dataSource.getConnection()) {
+            try (var preparedStmt = connection.prepareStatement(QueryExtensionCatalog.buildInsertExtensionsQuery())) {
+                List<Object> values = new ArrayList<>(6);
+                List<Map.Entry<OwnerInfo, Map<String, ExtensionAttributes>>> list = new ArrayList<>(extensions.entrySet());
+                for (List<Map.Entry<OwnerInfo, Map<String, ExtensionAttributes>>> subExtensions : Lists.partition(list, BATCH_SIZE)) {
+                    for (Map.Entry<OwnerInfo, Map<String, ExtensionAttributes>> entry : subExtensions) {
+                        for (Map.Entry<String, ExtensionAttributes> extension : entry.getValue().entrySet()) {
+                            values.clear();
+                            // In order, from the QueryCatalog.buildInsertExtensionsQuery SQL query :
+                            // equipmentId, equipmentType, networkUuid, variantNum, name, value_
+                            values.add(entry.getKey().getEquipmentId());
+                            values.add(entry.getKey().getEquipmentType().toString());
+                            values.add(entry.getKey().getNetworkUuid());
+                            values.add(entry.getKey().getVariantNum());
+                            values.add(extension.getKey());
+                            values.add(extension.getValue().toJson());
+                            bindValues(preparedStmt, values, mapper);
+                            preparedStmt.addBatch();
+                        }
+                    }
+                    preparedStmt.executeBatch();
+                }
+            }
+        } catch (SQLException e) {
+            throw new UncheckedSqlException(e);
+        }
+    }
+
+    public Map<OwnerInfo, Map<String, ExtensionAttributes>> getExtensionsWithInClause(UUID networkUuid, int variantNum, String columnNameForWhereClause, List<String> valuesForInClause) {
+        if (valuesForInClause.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        try (var connection = dataSource.getConnection()) {
+            var preparedStmt = connection.prepareStatement(QueryExtensionCatalog.buildExtensionsWithInClauseQuery(columnNameForWhereClause, valuesForInClause.size()));
+            preparedStmt.setObject(1, networkUuid);
+            preparedStmt.setInt(2, variantNum);
+            for (int i = 0; i < valuesForInClause.size(); i++) {
+                preparedStmt.setString(3 + i, valuesForInClause.get(i));
+            }
+
+            return innerGetExtensions(preparedStmt);
+        } catch (SQLException e) {
+            throw new UncheckedSqlException(e);
+        }
+    }
+
+    public Map<OwnerInfo, Map<String, ExtensionAttributes>> getExtensions(UUID networkUuid, int variantNum, String columnNameForWhereClause, String valueForWhereClause) {
+        try (var connection = dataSource.getConnection()) {
+            var preparedStmt = connection.prepareStatement(QueryExtensionCatalog.buildExtensionsQuery(columnNameForWhereClause));
+            preparedStmt.setObject(1, networkUuid);
+            preparedStmt.setInt(2, variantNum);
+            preparedStmt.setString(3, valueForWhereClause);
+
+            return innerGetExtensions(preparedStmt);
+        } catch (SQLException e) {
+            throw new UncheckedSqlException(e);
+        }
+    }
+
+    private Map<OwnerInfo, Map<String, ExtensionAttributes>> innerGetExtensions(PreparedStatement preparedStmt) throws SQLException {
+        try (ResultSet resultSet = preparedStmt.executeQuery()) {
+            Map<OwnerInfo, Map<String, ExtensionAttributes>> map = new HashMap<>();
+            while (resultSet.next()) {
+
+                OwnerInfo owner = new OwnerInfo();
+                // In order, from the QueryCatalog.buildInsertExtensionsQuery SQL query :
+                // equipmentId, equipmentType, networkUuid, variantNum, name, value_
+                owner.setEquipmentId(resultSet.getString(1));
+                owner.setEquipmentType(ResourceType.valueOf(resultSet.getString(2)));
+                owner.setNetworkUuid(UUID.fromString(resultSet.getString(3)));
+                owner.setVariantNum(resultSet.getInt(4));
+
+                String extensionName = resultSet.getString(5);
+                // TODO can do better than object mapper? Because otherwise need to use @class?
+                ExtensionAttributes extensionValue = mapper.readValue(resultSet.getString(6), ExtensionAttributes.class);
+
+                map.computeIfAbsent(owner, k -> new HashMap<>());
+                map.get(owner).put(extensionName, extensionValue);
+            }
+            return map;
+        } catch (JsonMappingException e) {
+            throw new RuntimeException(e);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected <T extends IdentifiableAttributes> Map<OwnerInfo, Map<String, ExtensionAttributes>> getExtensionsFromEquipments(UUID networkUuid, List<Resource<T>> resources) {
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> map = new HashMap<>();
+
+        if (!resources.isEmpty()) {
+            for (Resource<T> resource : resources) {
+                Map<String, ExtensionAttributes> extensions = resource.getAttributes().getExtensionAttributes();
+                if (extensions != null && !extensions.isEmpty()) {
+                    OwnerInfo info = new OwnerInfo(
+                            resource.getId(),
+                            resource.getType(),
+                            networkUuid,
+                            resource.getVariantNum()
+                    );
+                    map.put(info, extensions);
+                }
+            }
+        }
+        return map;
+    }
+
+    protected <T extends IdentifiableAttributes> void insertExtensionsInEquipments(UUID networkUuid, List<Resource<T>> equipments, Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions) {
+        if (!extensions.isEmpty() && !equipments.isEmpty()) {
+            for (Resource<T> equipmentAttributesResource : equipments) {
+                OwnerInfo owner = new OwnerInfo(
+                        equipmentAttributesResource.getId(),
+                        equipmentAttributesResource.getType(),
+                        networkUuid,
+                        equipmentAttributesResource.getVariantNum()
+                );
+                if (extensions.containsKey(owner)) {
+                    T attributes = equipmentAttributesResource.getAttributes();
+                    extensions.get(owner).forEach((key, value) -> {
+                        if (attributes != null && attributes.getExtensionAttributes() != null) {
+                            attributes.getExtensionAttributes().put(key, value);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    protected void deleteExtensions(UUID networkUuid, int variantNum, String equipmentId) {
+        deleteExtensions(networkUuid, variantNum, List.of(equipmentId));
+    }
+
+    protected void deleteExtensions(UUID networkUuid, int variantNum, List<String> equipmentIds) {
+        try (var connection = dataSource.getConnection()) {
+            try (var preparedStmt = connection.prepareStatement(QueryExtensionCatalog.buildDeleteExtensionsVariantEquipmentINQuery(equipmentIds.size()))) {
+                preparedStmt.setObject(1, networkUuid);
+                preparedStmt.setInt(2, variantNum);
+                for (int i = 0; i < equipmentIds.size(); i++) {
+                    preparedStmt.setString(3 + i, equipmentIds.get(i));
+                }
+                preparedStmt.executeUpdate();
+            }
+        } catch (SQLException e) {
+            throw new UncheckedSqlException(e);
+        }
+    }
+
+    protected <T extends IdentifiableAttributes> void deleteExtensions(UUID networkUuid, List<Resource<T>> resources) {
+        Map<Integer, List<String>> resourceIdsByVariant = new HashMap<>();
+        for (Resource<T> resource : resources) {
+            List<String> resourceIds = resourceIdsByVariant.get(resource.getVariantNum());
+            if (resourceIds != null) {
+                resourceIds.add(resource.getId());
+            } else {
+                resourceIds = new ArrayList<>();
+                resourceIds.add(resource.getId());
+            }
+            resourceIdsByVariant.put(resource.getVariantNum(), resourceIds);
+        }
+        resourceIdsByVariant.forEach((k, v) -> deleteExtensions(networkUuid, k, v));
+    }
+
+    //TODO tests
+    public <T extends IdentifiableAttributes> void updateExtensions(UUID networkUuid, List<Resource<T>> resources) {
+        deleteExtensions(networkUuid, resources);
+        insertExtensions(getExtensionsFromEquipments(networkUuid, resources));
+    }
+}

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/ExtensionHandler.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/ExtensionHandler.java
@@ -1,7 +1,12 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.network.store.server;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.powsybl.network.store.model.ExtensionAttributes;
@@ -22,6 +27,9 @@ import java.util.*;
 import static com.powsybl.network.store.server.NetworkStoreRepository.BATCH_SIZE;
 import static com.powsybl.network.store.server.Utils.bindValues;
 
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
 @Component
 public class ExtensionHandler {
     private final DataSource dataSource;
@@ -29,7 +37,7 @@ public class ExtensionHandler {
 
     public ExtensionHandler(DataSource dataSource, ObjectMapper mapper) {
         this.dataSource = dataSource;
-        this.mapper = mapper.enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature());
+        this.mapper = mapper;
     }
 
     public void insertExtensions(Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions) {
@@ -189,7 +197,7 @@ public class ExtensionHandler {
     }
 
     /**
-     * Extensions do not always exist in the initial variant and can be added by a
+     * Extensions do not always exist in the variant and can be added by a
      * modification for example. Instead of implementing an UPSERT, we delete then insert
      * the extensions.
      */

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/Mappings.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/Mappings.java
@@ -373,6 +373,7 @@ public class Mappings {
         batteryMappings.addColumnMapping(PROPERTIES, new ColumnMapping<>(Map.class, BatteryAttributes::getProperties, BatteryAttributes::setProperties));
         batteryMappings.addColumnMapping(ALIAS_BY_TYPE, new ColumnMapping<>(Map.class, BatteryAttributes::getAliasByType, BatteryAttributes::setAliasByType));
         batteryMappings.addColumnMapping(ALIASES_WITHOUT_TYPE, new ColumnMapping<>(Set.class, BatteryAttributes::getAliasesWithoutType, BatteryAttributes::setAliasesWithoutType));
+        batteryMappings.addColumnMapping(POSITION, new ColumnMapping<>(ConnectablePositionAttributes.class, BatteryAttributes::getPosition, BatteryAttributes::setPosition));
     }
 
     public TableMapping getBusbarSectionMappings() {

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/Mappings.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/Mappings.java
@@ -106,7 +106,6 @@ public class Mappings {
     private static final String CONNECTABLE_BUS = "connectableBus";
     private static final String CONNECTABLE_BUS_1 = "connectableBus1";
     private static final String CONNECTABLE_BUS_2 = "connectableBus2";
-    private static final String OPERATING_STATUS = "operatingStatus";
     private static final String FICTITIOUS = "fictitious";
     private static final String NODE = "node";
     private static final String NODE_1 = "node1";
@@ -154,7 +153,6 @@ public class Mappings {
         lineMappings.addColumnMapping("bus2", new ColumnMapping<>(String.class, LineAttributes::getBus2, LineAttributes::setBus2));
         lineMappings.addColumnMapping(CONNECTABLE_BUS_1, new ColumnMapping<>(String.class, LineAttributes::getConnectableBus1, LineAttributes::setConnectableBus1));
         lineMappings.addColumnMapping(CONNECTABLE_BUS_2, new ColumnMapping<>(String.class, LineAttributes::getConnectableBus2, LineAttributes::setConnectableBus2));
-        lineMappings.addColumnMapping(OPERATING_STATUS, new ColumnMapping<>(String.class, LineAttributes::getOperatingStatus, LineAttributes::setOperatingStatus));
         lineMappings.addColumnMapping("r", new ColumnMapping<>(Double.class, LineAttributes::getR, LineAttributes::setR));
         lineMappings.addColumnMapping("x", new ColumnMapping<>(Double.class, LineAttributes::getX, LineAttributes::setX));
         lineMappings.addColumnMapping("g1", new ColumnMapping<>(Double.class, LineAttributes::getG1, LineAttributes::setG1));
@@ -238,7 +236,6 @@ public class Mappings {
                 }
                 ((MinMaxReactiveLimitsAttributes) attributes.getReactiveLimits()).setMaxQ(value);
             }));
-        generatorMappings.addColumnMapping("activePowerControl", new ColumnMapping<>(ActivePowerControlAttributes.class, GeneratorAttributes::getActivePowerControl, GeneratorAttributes::setActivePowerControl));
         generatorMappings.addColumnMapping(REGULATION_TERMINAL, new ColumnMapping<>(TerminalRefAttributes.class, GeneratorAttributes::getRegulatingTerminal, GeneratorAttributes::setRegulatingTerminal));
         generatorMappings.addColumnMapping("coordinatedReactiveControl", new ColumnMapping<>(CoordinatedReactiveControlAttributes.class, GeneratorAttributes::getCoordinatedReactiveControl, GeneratorAttributes::setCoordinatedReactiveControl));
         generatorMappings.addColumnMapping("remoteReactivePowerControl", new ColumnMapping<>(RemoteReactivePowerControlAttributes.class, GeneratorAttributes::getRemoteReactivePowerControl, GeneratorAttributes::setRemoteReactivePowerControl));
@@ -248,7 +245,6 @@ public class Mappings {
         generatorMappings.addColumnMapping(ALIAS_BY_TYPE, new ColumnMapping<>(Map.class, GeneratorAttributes::getAliasByType, GeneratorAttributes::setAliasByType));
         generatorMappings.addColumnMapping(ALIASES_WITHOUT_TYPE, new ColumnMapping<>(Set.class, GeneratorAttributes::getAliasesWithoutType, GeneratorAttributes::setAliasesWithoutType));
         generatorMappings.addColumnMapping(POSITION, new ColumnMapping<>(ConnectablePositionAttributes.class, GeneratorAttributes::getPosition, GeneratorAttributes::setPosition));
-        generatorMappings.addColumnMapping("generatorStartup", new ColumnMapping<>(GeneratorStartupAttributes.class, GeneratorAttributes::getGeneratorStartupAttributes, GeneratorAttributes::setGeneratorStartupAttributes));
         generatorMappings.addColumnMapping("generatorShortCircuit", new ColumnMapping<>(GeneratorShortCircuitAttributes.class, GeneratorAttributes::getGeneratorShortCircuitAttributes, GeneratorAttributes::setGeneratorShortCircuitAttributes));
     }
 
@@ -373,12 +369,10 @@ public class Mappings {
                 }
                 ((MinMaxReactiveLimitsAttributes) attributes.getReactiveLimits()).setMaxQ(value);
             }));
-        batteryMappings.addColumnMapping("activePowerControl", new ColumnMapping<>(ActivePowerControlAttributes.class, BatteryAttributes::getActivePowerControl, BatteryAttributes::setActivePowerControl));
         batteryMappings.addColumnMapping("node", new ColumnMapping<>(Integer.class, BatteryAttributes::getNode, BatteryAttributes::setNode));
         batteryMappings.addColumnMapping(PROPERTIES, new ColumnMapping<>(Map.class, BatteryAttributes::getProperties, BatteryAttributes::setProperties));
         batteryMappings.addColumnMapping(ALIAS_BY_TYPE, new ColumnMapping<>(Map.class, BatteryAttributes::getAliasByType, BatteryAttributes::setAliasByType));
         batteryMappings.addColumnMapping(ALIASES_WITHOUT_TYPE, new ColumnMapping<>(Set.class, BatteryAttributes::getAliasesWithoutType, BatteryAttributes::setAliasesWithoutType));
-        batteryMappings.addColumnMapping(POSITION, new ColumnMapping<>(ConnectablePositionAttributes.class, BatteryAttributes::getPosition, BatteryAttributes::setPosition));
     }
 
     public TableMapping getBusbarSectionMappings() {
@@ -438,14 +432,12 @@ public class Mappings {
         danglingLineMappings.addColumnMapping(POSITION, new ColumnMapping<>(ConnectablePositionAttributes.class, DanglingLineAttributes::getPosition, DanglingLineAttributes::setPosition));
         danglingLineMappings.addColumnMapping(SELECTED_OPERATIONAL_LIMITS_GROUP_ID_COLUMN, new ColumnMapping<>(String.class, DanglingLineAttributes::getSelectedOperationalLimitsGroupId, DanglingLineAttributes::setSelectedOperationalLimitsGroupId));
         danglingLineMappings.addColumnMapping(TIE_LINE_ID, new ColumnMapping<>(String.class, DanglingLineAttributes::getTieLineId, DanglingLineAttributes::setTieLineId));
-        danglingLineMappings.addColumnMapping(OPERATING_STATUS, new ColumnMapping<>(String.class, DanglingLineAttributes::getOperatingStatus, DanglingLineAttributes::setOperatingStatus));
     }
 
     private void createTieLineMappings() {
         tieLineMappings.addColumnMapping("name", new ColumnMapping<>(String.class, TieLineAttributes::getName, TieLineAttributes::setName));
         tieLineMappings.addColumnMapping("danglingLine1Id", new ColumnMapping<>(String.class, TieLineAttributes::getDanglingLine1Id, TieLineAttributes::setDanglingLine1Id));
         tieLineMappings.addColumnMapping("danglingLine2Id", new ColumnMapping<>(String.class, TieLineAttributes::getDanglingLine2Id, TieLineAttributes::setDanglingLine2Id));
-        tieLineMappings.addColumnMapping(OPERATING_STATUS, new ColumnMapping<>(String.class, TieLineAttributes::getOperatingStatus, TieLineAttributes::setOperatingStatus));
     }
 
     public TableMapping getTieLineMappings() {
@@ -596,7 +588,6 @@ public class Mappings {
         hvdcLineMappings.addColumnMapping("converterStationId2", new ColumnMapping<>(String.class, HvdcLineAttributes::getConverterStationId2, HvdcLineAttributes::setConverterStationId2));
         hvdcLineMappings.addColumnMapping("hvdcAngleDroopActivePowerControl", new ColumnMapping<>(HvdcAngleDroopActivePowerControlAttributes.class, HvdcLineAttributes::getHvdcAngleDroopActivePowerControl, HvdcLineAttributes::setHvdcAngleDroopActivePowerControl));
         hvdcLineMappings.addColumnMapping("hvdcOperatorActivePowerRange", new ColumnMapping<>(HvdcOperatorActivePowerRangeAttributes.class, HvdcLineAttributes::getHvdcOperatorActivePowerRange, HvdcLineAttributes::setHvdcOperatorActivePowerRange));
-        hvdcLineMappings.addColumnMapping(OPERATING_STATUS, new ColumnMapping<>(String.class, HvdcLineAttributes::getOperatingStatus, HvdcLineAttributes::setOperatingStatus));
     }
 
     public TableMapping getTwoWindingsTransformerMappings() {
@@ -611,7 +602,6 @@ public class Mappings {
         twoWindingsTransformerMappings.addColumnMapping("bus2", new ColumnMapping<>(String.class, TwoWindingsTransformerAttributes::getBus2, TwoWindingsTransformerAttributes::setBus2));
         twoWindingsTransformerMappings.addColumnMapping(CONNECTABLE_BUS_1, new ColumnMapping<>(String.class, TwoWindingsTransformerAttributes::getConnectableBus1, TwoWindingsTransformerAttributes::setConnectableBus1));
         twoWindingsTransformerMappings.addColumnMapping(CONNECTABLE_BUS_2, new ColumnMapping<>(String.class, TwoWindingsTransformerAttributes::getConnectableBus2, TwoWindingsTransformerAttributes::setConnectableBus2));
-        twoWindingsTransformerMappings.addColumnMapping(OPERATING_STATUS, new ColumnMapping<>(String.class, TwoWindingsTransformerAttributes::getOperatingStatus, TwoWindingsTransformerAttributes::setOperatingStatus));
         twoWindingsTransformerMappings.addColumnMapping("r", new ColumnMapping<>(Double.class, TwoWindingsTransformerAttributes::getR, TwoWindingsTransformerAttributes::setR));
         twoWindingsTransformerMappings.addColumnMapping("x", new ColumnMapping<>(Double.class, TwoWindingsTransformerAttributes::getX, TwoWindingsTransformerAttributes::setX));
         twoWindingsTransformerMappings.addColumnMapping("g", new ColumnMapping<>(Double.class, TwoWindingsTransformerAttributes::getG, TwoWindingsTransformerAttributes::setG));
@@ -814,7 +804,6 @@ public class Mappings {
 
     private void createThreeWindingsTransformerMappings() {
         threeWindingsTransformerMappings.addColumnMapping("name", new ColumnMapping<>(String.class, ThreeWindingsTransformerAttributes::getName, ThreeWindingsTransformerAttributes::setName));
-        threeWindingsTransformerMappings.addColumnMapping(OPERATING_STATUS, new ColumnMapping<>(String.class, ThreeWindingsTransformerAttributes::getOperatingStatus, ThreeWindingsTransformerAttributes::setOperatingStatus));
         threeWindingsTransformerMappings.addColumnMapping("p1", new ColumnMapping<>(Double.class, ThreeWindingsTransformerAttributes::getP1, ThreeWindingsTransformerAttributes::setP1));
         threeWindingsTransformerMappings.addColumnMapping("q1", new ColumnMapping<>(Double.class, ThreeWindingsTransformerAttributes::getQ1, ThreeWindingsTransformerAttributes::setQ1));
         threeWindingsTransformerMappings.addColumnMapping("p2", new ColumnMapping<>(Double.class, ThreeWindingsTransformerAttributes::getP2, ThreeWindingsTransformerAttributes::setP2));

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -770,7 +770,6 @@ public class NetworkStoreRepository {
                 }
             }
         });
-        // TODO add a without auto commit??
         extensionHandler.updateExtensions(networkUuid, resources);
     }
 

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -656,7 +656,8 @@ public class NetworkStoreRepository {
         } catch (SQLException e) {
             throw new UncheckedSqlException(e);
         }
-        Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensions(networkUuid, variantNum, EQUIPMENT_TYPE_COLUMN, tableMapping.getResourceType().toString());
+        List<String> equipmentsIds = identifiables.stream().map(Resource::getId).toList();
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensionsWithInClause(networkUuid, variantNum, EQUIPMENT_ID_COLUMN, equipmentsIds);
         extensionHandler.insertExtensionsInEquipments(networkUuid, identifiables, extensions);
         return identifiables;
     }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/QueryCatalog.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/QueryCatalog.java
@@ -19,7 +19,7 @@ import static com.powsybl.network.store.server.Mappings.*;
  */
 public final class QueryCatalog {
 
-    private static final String MINIMAL_VALUE_REQUIREMENT_ERROR = "Function should not be called without at least one value.";
+    static final String MINIMAL_VALUE_REQUIREMENT_ERROR = "Function should not be called without at least one value.";
 
     static final String VARIANT_ID_COLUMN = "variantId";
     static final String UUID_COLUMN = "uuid";

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/QueryExtensionCatalog.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/QueryExtensionCatalog.java
@@ -25,7 +25,7 @@ public final class QueryExtensionCatalog {
                 " = ? and " + VARIANT_NUM_COLUMN + " = ?";
     }
 
-    public static String buildExtensionsQuery(String columnNameForWhereClause) {
+    public static String buildGetExtensionsQuery(String columnNameForWhereClause) {
         return "select " + EQUIPMENT_ID_COLUMN + ", " +
                 EQUIPMENT_TYPE_COLUMN + ", " +
                 NETWORK_UUID_COLUMN + ", " +
@@ -37,7 +37,7 @@ public final class QueryExtensionCatalog {
                 columnNameForWhereClause + " = ?";
     }
 
-    public static String buildExtensionsWithInClauseQuery(String columnNameForInClause, int numberOfValues) {
+    public static String buildGetExtensionsWithInClauseQuery(String columnNameForInClause, int numberOfValues) {
         if (numberOfValues < 1) {
             throw new IllegalArgumentException(MINIMAL_VALUE_REQUIREMENT_ERROR);
         }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/QueryExtensionCatalog.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/QueryExtensionCatalog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/QueryExtensionCatalog.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/QueryExtensionCatalog.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.server;
+
+import static com.powsybl.network.store.server.QueryCatalog.*;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+public final class QueryExtensionCatalog {
+    static final String EXTENSION_TABLE = "extension";
+
+    private QueryExtensionCatalog() {
+    }
+
+    public static String buildCloneExtensionsQuery() {
+        return "insert into " + EXTENSION_TABLE + "(" + EQUIPMENT_ID_COLUMN + ", " + EQUIPMENT_TYPE_COLUMN +
+                ", " + NETWORK_UUID_COLUMN + ", " + VARIANT_NUM_COLUMN + ", name, value_) select " +
+                EQUIPMENT_ID_COLUMN + ", " + EQUIPMENT_TYPE_COLUMN +
+                ", ?, ?, name, value_ from " + EXTENSION_TABLE + " where " + NETWORK_UUID_COLUMN +
+                " = ? and " + VARIANT_NUM_COLUMN + " = ?";
+    }
+
+    public static String buildExtensionsQuery(String columnNameForWhereClause) {
+        return "select " + EQUIPMENT_ID_COLUMN + ", " +
+                EQUIPMENT_TYPE_COLUMN + ", " +
+                NETWORK_UUID_COLUMN + ", " +
+                VARIANT_NUM_COLUMN + ", " +
+                "name, value_ " +
+                "from " + EXTENSION_TABLE + " where " +
+                NETWORK_UUID_COLUMN + " = ? and " +
+                VARIANT_NUM_COLUMN + " = ? and " +
+                columnNameForWhereClause + " = ?";
+    }
+
+    public static String buildExtensionsWithInClauseQuery(String columnNameForInClause, int numberOfValues) {
+        if (numberOfValues < 1) {
+            throw new IllegalArgumentException(MINIMAL_VALUE_REQUIREMENT_ERROR);
+        }
+        return "select " + EQUIPMENT_ID_COLUMN + ", " +
+                EQUIPMENT_TYPE_COLUMN + ", " +
+                NETWORK_UUID_COLUMN + ", " +
+                VARIANT_NUM_COLUMN + ", " +
+                "name, value_ " +
+                "from " + EXTENSION_TABLE + " where " +
+                NETWORK_UUID_COLUMN + " = ? and " +
+                VARIANT_NUM_COLUMN + " = ? and " +
+                columnNameForInClause + " in (" +
+                "?, ".repeat(numberOfValues - 1) + "?)";
+    }
+
+    public static String buildInsertExtensionsQuery() {
+        return "insert into " + EXTENSION_TABLE + "(" +
+                EQUIPMENT_ID_COLUMN + ", " + EQUIPMENT_TYPE_COLUMN + ", " +
+                NETWORK_UUID_COLUMN + " ," +
+                VARIANT_NUM_COLUMN + ", name, value_)" +
+                " values (?, ?, ?, ?, ?, ?)";
+    }
+
+    public static String buildDeleteExtensionsVariantEquipmentINQuery(int numberOfValues) {
+        if (numberOfValues < 1) {
+            throw new IllegalArgumentException(MINIMAL_VALUE_REQUIREMENT_ERROR);
+        }
+        return "delete from " + EXTENSION_TABLE + " where " +
+                NETWORK_UUID_COLUMN + " = ? and " +
+                VARIANT_NUM_COLUMN + " = ? and " +
+                EQUIPMENT_ID_COLUMN + " in (" +
+                "?, ".repeat(numberOfValues - 1) + "?)";
+    }
+
+    public static String buildDeleteExtensionsVariantQuery() {
+        return "delete from " + EXTENSION_TABLE + " where " +
+                NETWORK_UUID_COLUMN + " = ? and " +
+                VARIANT_NUM_COLUMN + " = ?";
+    }
+
+    public static String buildDeleteExtensionsQuery() {
+        return "delete from " + EXTENSION_TABLE + " where " +
+                NETWORK_UUID_COLUMN + " = ?";
+    }
+}

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/Utils.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/Utils.java
@@ -1,0 +1,83 @@
+package com.powsybl.network.store.server;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.network.store.model.IdentifiableAttributes;
+import com.powsybl.network.store.server.exceptions.UncheckedSqlException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public final class Utils {
+    private Utils() throws IllegalAccessException {
+        throw new IllegalAccessException("Utility class can not be initialize.");
+    }
+
+    private static boolean isCustomTypeJsonified(Class<?> clazz) {
+        return !(
+                Integer.class.equals(clazz) || Long.class.equals(clazz)
+                        || Float.class.equals(clazz) || Double.class.equals(clazz)
+                        || String.class.equals(clazz) || Boolean.class.equals(clazz)
+                        || UUID.class.equals(clazz)
+                        || Date.class.isAssignableFrom(clazz) // java.util.Date and java.sql.Date
+            );
+    }
+
+    static void bindValues(PreparedStatement statement, List<Object> values, ObjectMapper mapper) throws SQLException {
+        int idx = 0;
+        for (Object o : values) {
+            if (o instanceof Instant d) {
+                statement.setDate(++idx, new java.sql.Date(d.toEpochMilli()));
+            } else if (o == null || !isCustomTypeJsonified(o.getClass())) {
+                statement.setObject(++idx, o);
+            } else {
+                try {
+                    statement.setObject(++idx, mapper.writeValueAsString(o));
+                } catch (JsonProcessingException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+    }
+
+    static void bindAttributes(ResultSet resultSet, int columnIndex, ColumnMapping columnMapping, IdentifiableAttributes attributes, ObjectMapper mapper) {
+        try {
+            Object value = null;
+            if (columnMapping.getClassR() == null || isCustomTypeJsonified(columnMapping.getClassR())) {
+                String str = resultSet.getString(columnIndex);
+                if (str != null) {
+                    if (columnMapping.getClassMapKey() != null && columnMapping.getClassMapValue() != null) {
+                        value = mapper.readValue(str, mapper.getTypeFactory().constructMapType(Map.class, columnMapping.getClassMapKey(), columnMapping.getClassMapValue()));
+                    } else {
+                        if (columnMapping.getClassR() == null) {
+                            throw new PowsyblException("Invalid mapping config");
+                        }
+                        if (columnMapping.getClassR() == Instant.class) {
+                            value = resultSet.getTimestamp(columnIndex).toInstant();
+                        } else {
+                            value = mapper.readValue(str, columnMapping.getClassR());
+                        }
+                    }
+                }
+            } else {
+                value = resultSet.getObject(columnIndex, columnMapping.getClassR());
+            }
+            if (value != null) {
+                columnMapping.set(attributes, value);
+            }
+        } catch (SQLException e) {
+            throw new UncheckedSqlException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/Utils.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/Utils.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.network.store.server;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -17,6 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
 public final class Utils {
     private Utils() throws IllegalAccessException {
         throw new IllegalAccessException("Utility class can not be initialize.");

--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240306T120000Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240306T120000Z.xml
@@ -1,0 +1,47 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="abouhours" id="2986331049275-1">
+        <createTable tableName="extension">
+            <column name="equipmentid" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="equipmenttype" type="VARCHAR(255)"/>
+            <column name="networkuuid" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="variantnum" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value_" type="TEXT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="abouhours" id="2986331049275-2">
+        <createIndex indexName="extension_networkuuid_variantnum_equipmenttype_idx" tableName="extension">
+            <column name="networkuuid"/>
+            <column name="variantnum"/>
+            <column name="equipmenttype"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="abouhours" id="2986331049275-3">
+        <addPrimaryKey columnNames="networkuuid, variantnum, equipmentid, name" constraintName="extension_pkey" tableName="extension"/>
+    </changeSet>
+    <changeSet author="abouhours" id="2986331049275-4">
+        <!--        TODO finish migrations, it should not be necessary to add the @class with jsonb, it's for testing... -->
+<!--        <sql>-->
+<!--            INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)-->
+<!--            SELECT networkuuid, variantnum, id, 'BATTERY', 'activePowerControl',-->
+<!--                   jsonb_set(-->
+<!--                           COALESCE(activepowercontrol::jsonb, '{}'::jsonb),-->
+<!--                           '{@class}',-->
+<!--                           '"com.powsybl.network.store.model.ActivePowerControlAttributes"'::jsonb-->
+<!--                   )-->
+<!--            FROM battery-->
+<!--            WHERE activepowercontrol::jsonb IS NOT NULL-->
+<!--        </sql>-->
+    </changeSet>
+</databaseChangeLog>

--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240306T120000Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240306T120000Z.xml
@@ -26,8 +26,10 @@
         </createIndex>
         <addPrimaryKey columnNames="networkuuid, variantnum, equipmentid, name" constraintName="extension_pkey" tableName="extension"/>
     </changeSet>
+<!-- The data migration is skipped if the database is not postgres because we use jsonb methods that are specific to postgres -->
     <changeSet author="bouhoursant" id="2986331049277-2">
         <sqlFile
+                dbms="postgresql"
                 path="migrationExtensions_20240306T120000Z.sql"
                 relativeToChangelogFile="true"
                 splitStatements="true"

--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240306T120000Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240306T120000Z.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
-    <changeSet author="abouhours" id="2986331049275-1">
+    <changeSet author="bouhoursant" id="2986331049277-1">
         <createTable tableName="extension">
             <column name="equipmentid" type="VARCHAR(255)">
                 <constraints nullable="false"/>
@@ -19,29 +19,18 @@
             </column>
             <column name="value_" type="TEXT"/>
         </createTable>
-    </changeSet>
-    <changeSet author="abouhours" id="2986331049275-2">
         <createIndex indexName="extension_networkuuid_variantnum_equipmenttype_idx" tableName="extension">
             <column name="networkuuid"/>
             <column name="variantnum"/>
             <column name="equipmenttype"/>
         </createIndex>
-    </changeSet>
-    <changeSet author="abouhours" id="2986331049275-3">
         <addPrimaryKey columnNames="networkuuid, variantnum, equipmentid, name" constraintName="extension_pkey" tableName="extension"/>
     </changeSet>
-    <changeSet author="abouhours" id="2986331049275-4">
-        <!--        TODO finish migrations, it should not be necessary to add the @class with jsonb, it's for testing... -->
-<!--        <sql>-->
-<!--            INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)-->
-<!--            SELECT networkuuid, variantnum, id, 'BATTERY', 'activePowerControl',-->
-<!--                   jsonb_set(-->
-<!--                           COALESCE(activepowercontrol::jsonb, '{}'::jsonb),-->
-<!--                           '{@class}',-->
-<!--                           '"com.powsybl.network.store.model.ActivePowerControlAttributes"'::jsonb-->
-<!--                   )-->
-<!--            FROM battery-->
-<!--            WHERE activepowercontrol::jsonb IS NOT NULL-->
-<!--        </sql>-->
+    <changeSet author="bouhoursant" id="2986331049277-2">
+        <sqlFile
+                path="migrationExtensions_20240306T120000Z.sql"
+                relativeToChangelogFile="true"
+                splitStatements="true"
+                stripComments="true"/>
     </changeSet>
 </databaseChangeLog>

--- a/network-store-server/src/main/resources/db/changelog/changesets/migrationExtensions_20240306T120000Z.sql
+++ b/network-store-server/src/main/resources/db/changelog/changesets/migrationExtensions_20240306T120000Z.sql
@@ -1,9 +1,9 @@
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'BATTERY', 'activePowerControl',
        jsonb_set(
-               COALESCE(activepowercontrol::jsonb, '{}'::jsonb),
+               activepowercontrol::jsonb,
                '{@type}',
-               '"activePowerControl"'::jsonb
+               '"activePowerControl"'
        )
 FROM battery
 WHERE activepowercontrol IS NOT NULL;
@@ -11,7 +11,7 @@ WHERE activepowercontrol IS NOT NULL;
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'GENERATOR', 'activePowerControl',
        jsonb_set(
-               COALESCE(activepowercontrol::jsonb, '{}'::jsonb),
+               activepowercontrol::jsonb,
                '{@type}',
                '"activePowerControl"'::jsonb
        )
@@ -21,7 +21,7 @@ WHERE activepowercontrol IS NOT NULL;
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'GENERATOR', 'startup',
        jsonb_set(
-               COALESCE(generatorstartup::jsonb, '{}'::jsonb),
+               generatorstartup::jsonb,
                '{@type}',
                '"startup"'::jsonb
        )
@@ -32,7 +32,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'LINE', 'operatingStatus',
        jsonb_build_object(
                '@type', 'operatingStatus',
-               'operatingStatus', operatingStatus::text
+               'operatingStatus', operatingStatus
        )
 FROM line
 WHERE operatingStatus IS NOT NULL;
@@ -41,7 +41,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'HVDC_LINE', 'operatingStatus',
        jsonb_build_object(
                '@type', 'operatingStatus',
-               'operatingStatus', operatingStatus::text
+               'operatingStatus', operatingStatus
        )
 FROM hvdcline
 WHERE operatingStatus IS NOT NULL;
@@ -50,7 +50,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'TIE_LINE', 'operatingStatus',
        jsonb_build_object(
                '@type', 'operatingStatus',
-               'operatingStatus', operatingStatus::text
+               'operatingStatus', operatingStatus
        )
 FROM tieline
 WHERE operatingStatus IS NOT NULL;
@@ -59,7 +59,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'DANGLING_LINE', 'operatingStatus',
        jsonb_build_object(
                '@type', 'operatingStatus',
-               'operatingStatus', operatingStatus::text
+               'operatingStatus', operatingStatus
        )
 FROM danglingline
 WHERE operatingStatus IS NOT NULL;
@@ -68,7 +68,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'TWO_WINDINGS_TRANSFORMER', 'operatingStatus',
        jsonb_build_object(
                '@type', 'operatingStatus',
-               'operatingStatus', operatingStatus::text
+               'operatingStatus', operatingStatus
        )
 FROM twowindingstransformer
 WHERE operatingStatus IS NOT NULL;
@@ -77,7 +77,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'THREE_WINDINGS_TRANSFORMER', 'operatingStatus',
        jsonb_build_object(
                '@type', 'operatingStatus',
-               'operatingStatus', operatingStatus::text
+               'operatingStatus', operatingStatus
        )
 FROM threewindingstransformer
 WHERE operatingStatus IS NOT NULL;

--- a/network-store-server/src/main/resources/db/changelog/changesets/migrationExtensions_20240306T120000Z.sql
+++ b/network-store-server/src/main/resources/db/changelog/changesets/migrationExtensions_20240306T120000Z.sql
@@ -2,7 +2,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'BATTERY', 'activePowerControl',
        jsonb_set(
                activepowercontrol::jsonb,
-               '{@type}',
+               '{extensionName}',
                '"activePowerControl"'
        )
 FROM battery
@@ -12,7 +12,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'GENERATOR', 'activePowerControl',
        jsonb_set(
                activepowercontrol::jsonb,
-               '{@type}',
+               '{extensionName}',
                '"activePowerControl"'::jsonb
        )
 FROM generator
@@ -22,7 +22,7 @@ INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name
 SELECT networkuuid, variantnum, id, 'GENERATOR', 'startup',
        jsonb_set(
                generatorstartup::jsonb,
-               '{@type}',
+               '{extensionName}',
                '"startup"'::jsonb
        )
 FROM generator
@@ -31,7 +31,7 @@ WHERE generatorstartup IS NOT NULL;
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'LINE', 'operatingStatus',
        jsonb_build_object(
-               '@type', 'operatingStatus',
+               'extensionName', 'operatingStatus',
                'operatingStatus', operatingStatus
        )
 FROM line
@@ -40,7 +40,7 @@ WHERE operatingStatus IS NOT NULL;
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'HVDC_LINE', 'operatingStatus',
        jsonb_build_object(
-               '@type', 'operatingStatus',
+               'extensionName', 'operatingStatus',
                'operatingStatus', operatingStatus
        )
 FROM hvdcline
@@ -49,7 +49,7 @@ WHERE operatingStatus IS NOT NULL;
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'TIE_LINE', 'operatingStatus',
        jsonb_build_object(
-               '@type', 'operatingStatus',
+               'extensionName', 'operatingStatus',
                'operatingStatus', operatingStatus
        )
 FROM tieline
@@ -58,7 +58,7 @@ WHERE operatingStatus IS NOT NULL;
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'DANGLING_LINE', 'operatingStatus',
        jsonb_build_object(
-               '@type', 'operatingStatus',
+               'extensionName', 'operatingStatus',
                'operatingStatus', operatingStatus
        )
 FROM danglingline
@@ -67,7 +67,7 @@ WHERE operatingStatus IS NOT NULL;
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'TWO_WINDINGS_TRANSFORMER', 'operatingStatus',
        jsonb_build_object(
-               '@type', 'operatingStatus',
+               'extensionName', 'operatingStatus',
                'operatingStatus', operatingStatus
        )
 FROM twowindingstransformer
@@ -76,7 +76,7 @@ WHERE operatingStatus IS NOT NULL;
 INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
 SELECT networkuuid, variantnum, id, 'THREE_WINDINGS_TRANSFORMER', 'operatingStatus',
        jsonb_build_object(
-               '@type', 'operatingStatus',
+               'extensionName', 'operatingStatus',
                'operatingStatus', operatingStatus
        )
 FROM threewindingstransformer

--- a/network-store-server/src/main/resources/db/changelog/changesets/migrationExtensions_20240306T120000Z.sql
+++ b/network-store-server/src/main/resources/db/changelog/changesets/migrationExtensions_20240306T120000Z.sql
@@ -1,0 +1,83 @@
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'BATTERY', 'activePowerControl',
+       jsonb_set(
+               COALESCE(activepowercontrol::jsonb, '{}'::jsonb),
+               '{@type}',
+               '"activePowerControl"'::jsonb
+       )
+FROM battery
+WHERE activepowercontrol IS NOT NULL;
+
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'GENERATOR', 'activePowerControl',
+       jsonb_set(
+               COALESCE(activepowercontrol::jsonb, '{}'::jsonb),
+               '{@type}',
+               '"activePowerControl"'::jsonb
+       )
+FROM generator
+WHERE activepowercontrol IS NOT NULL;
+
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'GENERATOR', 'startup',
+       jsonb_set(
+               COALESCE(generatorstartup::jsonb, '{}'::jsonb),
+               '{@type}',
+               '"startup"'::jsonb
+       )
+FROM generator
+WHERE generatorstartup IS NOT NULL;
+
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'LINE', 'operatingStatus',
+       jsonb_build_object(
+               '@type', 'operatingStatus',
+               'operatingStatus', operatingStatus::text
+       )
+FROM line
+WHERE operatingStatus IS NOT NULL;
+
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'HVDC_LINE', 'operatingStatus',
+       jsonb_build_object(
+               '@type', 'operatingStatus',
+               'operatingStatus', operatingStatus::text
+       )
+FROM hvdcline
+WHERE operatingStatus IS NOT NULL;
+
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'TIE_LINE', 'operatingStatus',
+       jsonb_build_object(
+               '@type', 'operatingStatus',
+               'operatingStatus', operatingStatus::text
+       )
+FROM tieline
+WHERE operatingStatus IS NOT NULL;
+
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'DANGLING_LINE', 'operatingStatus',
+       jsonb_build_object(
+               '@type', 'operatingStatus',
+               'operatingStatus', operatingStatus::text
+       )
+FROM danglingline
+WHERE operatingStatus IS NOT NULL;
+
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'TWO_WINDINGS_TRANSFORMER', 'operatingStatus',
+       jsonb_build_object(
+               '@type', 'operatingStatus',
+               'operatingStatus', operatingStatus::text
+       )
+FROM twowindingstransformer
+WHERE operatingStatus IS NOT NULL;
+
+INSERT INTO extension (networkuuid, variantnum, equipmentid, equipmentType, name, value_)
+SELECT networkuuid, variantnum, id, 'THREE_WINDINGS_TRANSFORMER', 'operatingStatus',
+       jsonb_build_object(
+               '@type', 'operatingStatus',
+               'operatingStatus', operatingStatus::text
+       )
+FROM threewindingstransformer
+WHERE operatingStatus IS NOT NULL;

--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -39,3 +39,7 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20240223T120001Z.xml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/changelog_20240306T120000Z.xml
+      relativeToChangelogFile: true

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/ExtensionHandlerTest.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/ExtensionHandlerTest.java
@@ -1,0 +1,283 @@
+package com.powsybl.network.store.server;
+
+import com.powsybl.network.store.model.*;
+import com.powsybl.network.store.server.dto.OwnerInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ExtensionHandlerTest {
+
+    @DynamicPropertySource
+    static void makeTestDbSuffix(DynamicPropertyRegistry registry) {
+        UUID uuid = UUID.randomUUID();
+        registry.add("testDbSuffix", () -> uuid);
+    }
+
+    @Autowired
+    private ExtensionHandler extensionHandler;
+
+    private static final UUID NETWORK_UUID = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
+
+    @Test
+    public void insertExtensionsInBatteryTest() {
+
+        String equipmentIdA = "idBatteryA";
+        String equipmentIdB = "idBatteryB";
+
+        OwnerInfo infoBatteryA = new OwnerInfo(
+                equipmentIdA,
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+        OwnerInfo infoBatteryB = new OwnerInfo(
+                equipmentIdB,
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+        OwnerInfo infoBatteryX = new OwnerInfo(
+                "badID",
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+
+        Resource<BatteryAttributes> resBatteryA = Resource.batteryBuilder()
+                .id(equipmentIdA)
+                .attributes(BatteryAttributes.builder()
+                        .voltageLevelId("vl1")
+                        .name("batteryA")
+                        .targetP(250)
+                        .targetQ(100)
+                        .maxP(500)
+                        .minP(100)
+                        .reactiveLimits(MinMaxReactiveLimitsAttributes.builder().maxQ(10).minQ(11).build())
+                        .build())
+                .build();
+
+        Resource<BatteryAttributes> resBatteryB = Resource.batteryBuilder()
+                .id(equipmentIdB)
+                .attributes(BatteryAttributes.builder()
+                        .voltageLevelId("vl1")
+                        .name("batteryB")
+                        .targetP(250)
+                        .targetQ(100)
+                        .maxP(500)
+                        .minP(100)
+                        .reactiveLimits(MinMaxReactiveLimitsAttributes.builder().maxQ(5).minQ(6).build())
+                        .build())
+                .build();
+
+        List<Resource<BatteryAttributes>> batteries = new ArrayList<>();
+        batteries.add(resBatteryA);
+        batteries.add(resBatteryB);
+
+        assertEquals(resBatteryA.getId(), infoBatteryA.getEquipmentId());
+        assertEquals(resBatteryB.getId(), infoBatteryB.getEquipmentId());
+        assertNotEquals(resBatteryA.getId(), infoBatteryX.getEquipmentId());
+
+        Map<String, ExtensionAttributes> extensionAttributesMapA = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(6.0).participate(true).participationFactor(1.5).build(),
+                "operatingStatus", OperatingStatusAttributes.builder().operatingStatus("test12").build());
+        Map<String, ExtensionAttributes> extensionAttributesMapB = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(5.0).participate(false).participationFactor(0.5).build(),
+                "operatingStatus", OperatingStatusAttributes.builder().operatingStatus("test23").build());
+
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> mapA = new HashMap<>();
+        mapA.put(infoBatteryA, extensionAttributesMapA);
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> mapB = new HashMap<>();
+        mapB.put(infoBatteryB, extensionAttributesMapB);
+
+        assertEquals(resBatteryA.getAttributes().getExtensionAttributes(), new HashMap<>());
+        assertNull(resBatteryA.getAttributes().getExtensionAttributes().get("activePowerControl"));
+        assertNull(resBatteryA.getAttributes().getExtensionAttributes().get("operatingStatus"));
+        assertEquals(resBatteryB.getAttributes().getExtensionAttributes(), new HashMap<>());
+        assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("activePowerControl"));
+        assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("operatingStatus"));
+
+        extensionHandler.insertExtensionsInEquipments(NETWORK_UUID, batteries, new HashMap<>());
+
+        assertEquals(resBatteryA.getAttributes().getExtensionAttributes(), new HashMap<>());
+        assertNull(resBatteryA.getAttributes().getExtensionAttributes().get("activePowerControl"));
+        assertNull(resBatteryA.getAttributes().getExtensionAttributes().get("operatingStatus"));
+        assertEquals(resBatteryB.getAttributes().getExtensionAttributes(), new HashMap<>());
+        assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("activePowerControl"));
+        assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("operatingStatus"));
+
+        extensionHandler.insertExtensionsInEquipments(NETWORK_UUID, batteries, mapA);
+        assertNotNull(resBatteryA.getAttributes().getExtensionAttributes().get("activePowerControl"));
+        assertNotNull(resBatteryA.getAttributes().getExtensionAttributes().get("operatingStatus"));
+        assertEquals(resBatteryB.getAttributes().getExtensionAttributes(), new HashMap<>());
+        assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("activePowerControl"));
+        assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("operatingStatus"));
+
+        extensionHandler.insertExtensionsInEquipments(NETWORK_UUID, batteries, mapB);
+        assertNotNull(resBatteryA.getAttributes().getExtensionAttributes().get("activePowerControl"));
+        assertNotNull(resBatteryA.getAttributes().getExtensionAttributes().get("operatingStatus"));
+        assertNotNull(resBatteryB.getAttributes().getExtensionAttributes().get("activePowerControl"));
+        assertNotNull(resBatteryB.getAttributes().getExtensionAttributes().get("operatingStatus"));
+    }
+
+    @Test
+    public void insertExtensionsTest() {
+        String equipmentIdA = "idBatteryA";
+
+        OwnerInfo infoBatteryA = new OwnerInfo(
+                equipmentIdA,
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+        Map<String, ExtensionAttributes> extensionAttributesMapA = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(6.0).participate(true).participationFactor(1.5).build(),
+                "operatingStatus", OperatingStatusAttributes.builder().operatingStatus("test23").build());
+
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> mapA = new HashMap<>();
+        mapA.put(infoBatteryA, extensionAttributesMapA);
+
+        extensionHandler.insertExtensions(mapA);
+
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensions(NETWORK_UUID, 0, "equipmentId", "idBatteryA");
+        Map<String, ExtensionAttributes> extensionAttributes = extensions.get(infoBatteryA);
+        assertEquals(2, extensionAttributes.size());
+        assertNotNull(extensionAttributes.get("activePowerControl"));
+        ActivePowerControlAttributes activePowerControl = (ActivePowerControlAttributes) extensionAttributes.get("activePowerControl");
+        assertTrue(activePowerControl.isParticipate());
+        assertEquals(6.0, activePowerControl.getDroop(), 0.1);
+        assertEquals(1.5, activePowerControl.getParticipationFactor(), 0.1);
+        assertNotNull(extensionAttributes.get("operatingStatus"));
+        assertEquals(ActivePowerControlAttributes.class, activePowerControl.getClass());
+        assertEquals(OperatingStatusAttributes.class, extensionAttributes.get("operatingStatus").getClass());
+    }
+
+    @Test
+    public void getExtensionsWithInClauseTest() {
+        String equipmentIdA = "idBatteryA";
+        String equipmentIdB = "idBatteryB";
+
+        OwnerInfo infoBatteryA = new OwnerInfo(
+                equipmentIdA,
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+        OwnerInfo infoBatteryB = new OwnerInfo(
+                equipmentIdB,
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+        Map<String, ExtensionAttributes> extensionAttributesMapA = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(6.0).participate(true).participationFactor(1.5).build(),
+                "operatingStatus", OperatingStatusAttributes.builder().operatingStatus("test12").build());
+        Map<String, ExtensionAttributes> extensionAttributesMapB = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(5.0).participate(false).participationFactor(0.5).build(),
+                "operatingStatus", OperatingStatusAttributes.builder().operatingStatus("test23").build());
+
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> mapA = new HashMap<>();
+        mapA.put(infoBatteryA, extensionAttributesMapA);
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> mapB = new HashMap<>();
+        mapB.put(infoBatteryB, extensionAttributesMapB);
+
+        extensionHandler.insertExtensions(mapA);
+        extensionHandler.insertExtensions(mapB);
+
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensionsWithInClause(NETWORK_UUID, 0, "equipmentId", List.of("idBatteryA", "idBatteryB"));
+        assertEquals(2, extensions.size());
+        assertNotNull(extensions.get(infoBatteryA));
+        Map<String, ExtensionAttributes> expBatteryA = extensionHandler.getExtensions(NETWORK_UUID, 0, "equipmentId", equipmentIdA).get(infoBatteryA);
+        assertEquals(expBatteryA, extensions.get(infoBatteryA));
+        assertNotNull(extensions.get(infoBatteryB));
+        Map<String, ExtensionAttributes> expBatteryB = extensionHandler.getExtensions(NETWORK_UUID, 0, "equipmentId", equipmentIdB).get(infoBatteryB);
+        assertEquals(expBatteryB, extensions.get(infoBatteryB));
+    }
+
+    @Test
+    public void deleteExtensionsTest() {
+        String equipmentIdA = "idBatteryA";
+        String equipmentIdB = "idBatteryB";
+
+        OwnerInfo infoBatteryA = new OwnerInfo(
+                equipmentIdA,
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+        OwnerInfo infoBatteryB = new OwnerInfo(
+                equipmentIdB,
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+        Map<String, ExtensionAttributes> extensionAttributesMapA = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(6.0).participate(true).participationFactor(1.5).build(),
+                "operatingStatus", OperatingStatusAttributes.builder().operatingStatus("test12").build());
+        Map<String, ExtensionAttributes> extensionAttributesMapB = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(5.0).participate(false).participationFactor(0.5).build(),
+                "operatingStatus", OperatingStatusAttributes.builder().operatingStatus("test23").build());
+
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> mapA = new HashMap<>();
+        mapA.put(infoBatteryA, extensionAttributesMapA);
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> mapB = new HashMap<>();
+        mapB.put(infoBatteryB, extensionAttributesMapB);
+
+        extensionHandler.insertExtensions(mapA);
+        extensionHandler.insertExtensions(mapB);
+
+        extensionHandler.deleteExtensions(NETWORK_UUID, 0, "idBatteryA");
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensionsWithInClause(NETWORK_UUID, 0, "equipmentId", List.of("idBatteryA", "idBatteryB"));
+        assertEquals(1, extensions.size());
+        Resource<BatteryAttributes> batteryB = Resource.batteryBuilder().id("idBatteryB").attributes(new BatteryAttributes()).build();
+        extensionHandler.deleteExtensions(NETWORK_UUID, List.of(batteryB));
+        extensions = extensionHandler.getExtensionsWithInClause(NETWORK_UUID, 0, "equipmentId", List.of("idBatteryA", "idBatteryB"));
+        assertEquals(0, extensions.size());
+    }
+
+    @Test
+    public void updateExtensionsTest() {
+        String equipmentIdA = "idBatteryA";
+
+        OwnerInfo infoBatteryA = new OwnerInfo(
+                equipmentIdA,
+                ResourceType.BATTERY,
+                NETWORK_UUID,
+                Resource.INITIAL_VARIANT_NUM
+        );
+        Map<String, ExtensionAttributes> extensionAttributesMapA = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(6.0).participate(true).participationFactor(1.5).build());
+
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> mapA = new HashMap<>();
+        mapA.put(infoBatteryA, extensionAttributesMapA);
+
+        extensionHandler.insertExtensions(mapA);
+
+        Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensions(NETWORK_UUID, 0, "equipmentId", "idBatteryA");
+        Map<String, ExtensionAttributes> extensionAttributes = extensions.get(infoBatteryA);
+        assertEquals(1, extensionAttributes.size());
+        assertNotNull(extensionAttributes.get("activePowerControl"));
+        ActivePowerControlAttributes activePowerControl = (ActivePowerControlAttributes) extensionAttributes.get("activePowerControl");
+        assertTrue(activePowerControl.isParticipate());
+        assertEquals(6.0, activePowerControl.getDroop(), 0.1);
+        assertEquals(1.5, activePowerControl.getParticipationFactor(), 0.1);
+
+        extensionAttributesMapA = Map.of("activePowerControl", ActivePowerControlAttributes.builder().droop(10.0).participate(false).participationFactor(2.0).build());
+        BatteryAttributes batteryAttributes = new BatteryAttributes();
+        batteryAttributes.setExtensionAttributes(extensionAttributesMapA);
+        Resource<BatteryAttributes> batteryA = Resource.batteryBuilder().id("idBatteryA").attributes(batteryAttributes).build();
+        extensionHandler.updateExtensions(NETWORK_UUID, List.of(batteryA));
+        extensions = extensionHandler.getExtensions(NETWORK_UUID, 0, "equipmentId", "idBatteryA");
+        extensionAttributes = extensions.get(infoBatteryA);
+        activePowerControl = (ActivePowerControlAttributes) extensionAttributes.get("activePowerControl");
+        assertFalse(activePowerControl.isParticipate());
+        assertEquals(10.0, activePowerControl.getDroop(), 0.1);
+        assertEquals(2.0, activePowerControl.getParticipationFactor(), 0.1);
+    }
+}

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/ExtensionHandlerTest.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/ExtensionHandlerTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.network.store.server;
 
 import com.powsybl.network.store.model.*;
@@ -16,6 +22,9 @@ import java.util.*;
 
 import static org.junit.Assert.*;
 
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -68,6 +68,7 @@ public class NetworkStoreControllerIT {
                 .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
     }
 
+    //TODO test extension attributes in this elephant test
     @Test
     public void test() throws Exception {
         mvc.perform(get("/" + VERSION + "/networks")

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -68,7 +68,6 @@ public class NetworkStoreControllerIT {
                 .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
     }
 
-    //TODO test extension attributes in this elephant test
     @Test
     public void test() throws Exception {
         mvc.perform(get("/" + VERSION + "/networks")

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreRepositoryTest.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreRepositoryTest.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.LimitType;
 import com.powsybl.network.store.model.*;
 import com.powsybl.network.store.server.dto.LimitsInfos;
 import com.powsybl.network.store.server.dto.OwnerInfo;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreRepositoryTest.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreRepositoryTest.java
@@ -10,7 +10,6 @@ import com.powsybl.iidm.network.LimitType;
 import com.powsybl.network.store.model.*;
 import com.powsybl.network.store.server.dto.LimitsInfos;
 import com.powsybl.network.store.server.dto.OwnerInfo;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -567,7 +566,6 @@ public class NetworkStoreRepositoryTest {
                 .attributes(ThreeWindingsTransformerAttributes.builder()
                         .name("id3WTransformerA")
                         .ratedU0(1)
-                        .operatingStatus("IN_OPERATION")
                         .leg1(LegAttributes.builder()
                                 .ratioTapChangerAttributes(RatioTapChangerAttributes.builder()
                                 .lowTapPosition(20)
@@ -584,7 +582,6 @@ public class NetworkStoreRepositoryTest {
                 .attributes(ThreeWindingsTransformerAttributes.builder()
                         .name("id3WTransformerB")
                         .ratedU0(1)
-                        .operatingStatus("IN_OPERATION")
                         .leg1(new LegAttributes())
                         .leg2(LegAttributes.builder()
                                 .phaseTapChangerAttributes(PhaseTapChangerAttributes.builder()

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <properties>
         <sirocco.version>1.0</sirocco.version>
 
-        <powsybl-ws-dependencies.version>2.8.0</powsybl-ws-dependencies.version>
+        <powsybl-ws-dependencies.version>2.9.0</powsybl-ws-dependencies.version>
 
         <!-- FIXME : to remove when sonar version is updated on github actions -->
         <!-- https://community.sonarsource.com/t/stackoverflowerror-at-defaultinputcomponent-equals/20324 -->


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It adds the ability to handle extensions discovered by service loader in the network store in a separate table "extension" instead of storing the extension with the identifiable. This introduces the possibility of not having the implementation of the extension in the network-store. 
3 existing extensions have been migrated to this new framework: OperatingStatus, GeneratorStartup, ActivePowerControl.
The migration from the old framework to the new one is handled with SQL script in Liquibase. 

This PR relies on https://github.com/powsybl/powsybl-network-store/pull/383

## Notes
* Migration
&rarr; Dump of dev-opf data => 7866159 extensions (OperatingStatus, GeneratorStartup or ActivePowerControl), migrated in 1 minute.
&rarr; The data migration is only done for postgres but the schema migration for all dbms. 
&rarr; The migration does not drop the columns activePowerControl, operatingStatus and startup. This will be done in a future migration to be able to fallback on the previous implementation without data loss.
* Use extension name in the column instead of adding "extensionName" in the stored json
&rarr; I haven't found a way to deserialize the json without adding the "extensionName" field when storing it (e.g. `{"extensionName":"activePowerControl","participate":true,"droop":0.0,"participationFactor":"NaN"}`). The extensionName value is already stored in the "name" column so we could use it (?).
&rarr;  I added a runtime dependencies to powsybl-network-store-iidm-impl to be able to discover ExtensionLoaders in this dependency at runtime.
* Performance
&rarr; On my computer, on a THT/HT study with 12000 extensions and ~6000 generators, we measure the time spent in NetworkStoreRepository methods only:     

|                                                              | main    | generalize-extension | overhead |
|--------------------------------------------------------------|---------|----------------------|----------|
| create all identifiables                                          | 8.5 s   | 9 s                  | 5%       |
| get identifiable (all generators)                            | 0.2 s   | 0.25 s               | 25%      |
| update identifiable (tabular modification - 6000 generators) | 1 s     | 1.2 s                | 20%      |
| delete identifiable (1 generator)                            | 0.002 s | 0.004 s              | 100%     |

