### PR TITLE
Fix migration for 3WT ratiotapchangerregulationmode

### DIFF
--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240325T120001Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240325T120001Z.xml
@@ -1,0 +1,19 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="bouhoursant" id="2986331049276-1">
+        <update tableName="threewindingstransformer">
+            <column name="ratiotapchangerregulationmode1" value='"VOLTAGE"'/>
+            <where>ratiotapchangerregulationmode1 = 'VOLTAGE'</where>
+        </update>
+        <update tableName="threewindingstransformer">
+            <column name="ratiotapchangerregulationmode2" value='"VOLTAGE"'/>
+            <where>ratiotapchangerregulationmode2 = 'VOLTAGE'</where>
+        </update>
+        <update tableName="threewindingstransformer">
+            <column name="ratiotapchangerregulationmode3" value='"VOLTAGE"'/>
+            <where>ratiotapchangerregulationmode3 = 'VOLTAGE'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -39,3 +39,7 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20240223T120001Z.xml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/changelog_20240325T120001Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Fix migration where the value of ratiotapchangerregulationmode1, ratiotapchangerregulationmode2, ratiotapchangerregulationmode3 was set to VOLTAGE where it should have been set to "VOLTAGE"
