### PR TITLE
Add support for network generalized extensions

### DIFF
--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -5210,4 +5210,34 @@ public class NetworkStoreIT {
             assertEquals(2, twt2.getRatioTapChanger().getHighTapPosition());
         }
     }
+
+    @Test
+    public void testNetworkExtension() {
+        String filePath = "/network_test1_cgmes_metadata_models.xml";
+        ReadOnlyDataSource dataSource = getResource(filePath, filePath);
+
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            // import new network in the store with extension cgmesMetadataModels
+            Network network = service.importNetwork(dataSource);
+            service.flush(network);
+        }
+
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Map<UUID, String> networkIds = service.getNetworkIds();
+            assertEquals(1, networkIds.size());
+
+            // check that the stored network contains the extension cgmesMetadataModels
+            UUID initialNetworkUuid = networkIds.keySet().stream().findFirst().get();
+            Network readNetwork = service.getNetwork(initialNetworkUuid);
+            assertNotNull(readNetwork.getExtensionByName("cgmesMetadataModels"));
+
+            // clone network
+            Network clonedNetwork = service.cloneNetwork(initialNetworkUuid, List.of("InitialState"));
+            UUID clonedNetworkUuid = service.getNetworkUuid(clonedNetwork);
+            Network readClonedNetwork = service.getNetwork(clonedNetworkUuid);
+            assertNotNull(readClonedNetwork.getExtensionByName("cgmesMetadataModels"));
+
+            service.deleteAllNetworks();
+        }
+    }
 }

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -4568,7 +4568,8 @@ public class NetworkStoreIT {
         try (NetworkStoreService service = createNetworkStoreService()) {
             // import new network in the store
             Network network = service.importNetwork(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource());
-            assertNull(network.getExtension(Object.class));
+            // FIXME to be removed at next powsybl-network-store upgrade
+            // assertNull(network.getExtension(Object.class));
             assertNull(network.getExtensionByName(""));
             BaseVoltageMapping baseVoltageMapping = network.getExtension(BaseVoltageMapping.class);
             assertNotNull(baseVoltageMapping);

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -12,6 +12,8 @@ import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
 import com.powsybl.cgmes.extensions.*;
+import com.powsybl.cgmes.model.CgmesMetadataModel;
+import com.powsybl.cgmes.model.CgmesSubset;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
@@ -33,6 +35,10 @@ import com.powsybl.network.store.client.RestClientImpl;
 import com.powsybl.network.store.iidm.impl.ConfiguredBusImpl;
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
 import com.powsybl.network.store.iidm.impl.NetworkImpl;
+import com.powsybl.network.store.model.BaseVoltageSourceAttribute;
+import com.powsybl.network.store.model.CgmesMetadataModelAttributes;
+import com.powsybl.network.store.model.CgmesMetadataModelsAttributes;
+import com.powsybl.network.store.model.CimCharacteristicsAttributes;
 import com.powsybl.network.store.server.NetworkStoreApplication;
 import com.powsybl.ucte.converter.UcteImporter;
 import org.apache.commons.collections4.IterableUtils;
@@ -1564,230 +1570,229 @@ public class NetworkStoreIT {
         }
     }
 
-    //TODO: reactivate this test in https://github.com/powsybl/powsybl-network-store-server/pull/32
-//    @Test
-//    public void cgmesExtensionsTest() {
-//        try (NetworkStoreService service = createNetworkStoreService()) {
-//            // import new network in the store
-//            Network network = service.importNetwork(CgmesConformity1Catalog.miniNodeBreaker().dataSource());
-//            service.flush(network);
-//        }
-//
-//        try (NetworkStoreService service = createNetworkStoreService()) {
-//            Map<UUID, String> networkIds = service.getNetworkIds();
-//            assertEquals(1, networkIds.size());
-//
-//            // get extensions by name
-//            Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
-//            CgmesMetadataModels cgmesMetadataModels = readNetwork.getExtensionByName("cgmesMetadataModels");
-//            CimCharacteristics cimCharacteristics = readNetwork.getExtensionByName("cimCharacteristics");
-//
-//            Optional<CgmesMetadataModel> cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
-//            assertTrue(cgmesSvMetadataModel.isPresent());
-//            CgmesMetadataModel cgmesSvMetadata = cgmesSvMetadataModel.get();
-//            assertEquals(573, cgmesSvMetadata.getDescription().length());
-//            assertTrue(cgmesSvMetadata.getDescription().contains("CGMES Conformity Assessment"));
-//            assertEquals(4, cgmesSvMetadata.getVersion());
-//            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSvMetadata.getModelingAuthoritySet());
-//            assertEquals(3, cgmesSvMetadata.getDependentOn().size());
-//
-//            Optional<CgmesMetadataModel> cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
-//            assertTrue(cgmesSshMetadataModel.isPresent());
-//            CgmesMetadataModel cgmesSshMetadata = cgmesSshMetadataModel.get();
-//            assertEquals(573, cgmesSshMetadata.getDescription().length());
-//            assertTrue(cgmesSshMetadata.getDescription().contains("CGMES Conformity Assessment"));
-//            assertEquals(4, cgmesSshMetadata.getVersion());
-//            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSshMetadata.getModelingAuthoritySet());
-//            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
-//
-//            assertEquals(CgmesTopologyKind.NODE_BREAKER, cimCharacteristics.getTopologyKind());
-//            assertEquals(16, cimCharacteristics.getCimVersion());
-//
-//            // get extensions by class
-//            cgmesMetadataModels = readNetwork.getExtension(CgmesMetadataModels.class);
-//            cimCharacteristics = readNetwork.getExtension(CimCharacteristics.class);
-//            cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
-//
-//            assertTrue(cgmesSvMetadataModel.isPresent());
-//            cgmesSvMetadata = cgmesSvMetadataModel.get();
-//            assertEquals(573, cgmesSvMetadata.getDescription().length());
-//            assertTrue(cgmesSvMetadata.getDescription().contains("CGMES Conformity Assessment"));
-//            assertEquals(4, cgmesSvMetadata.getVersion());
-//            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSvMetadata.getModelingAuthoritySet());
-//            assertEquals(3, cgmesSvMetadata.getDependentOn().size());
-//
-//            cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
-//            assertTrue(cgmesSshMetadataModel.isPresent());
-//            cgmesSshMetadata = cgmesSshMetadataModel.get();
-//            assertEquals(573, cgmesSshMetadata.getDescription().length());
-//            assertTrue(cgmesSshMetadata.getDescription().contains("CGMES Conformity Assessment"));
-//            assertEquals(4, cgmesSshMetadata.getVersion());
-//            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSshMetadata.getModelingAuthoritySet());
-//            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
-//
-//            assertEquals(CgmesTopologyKind.NODE_BREAKER, cimCharacteristics.getTopologyKind());
-//            assertEquals(16, cimCharacteristics.getCimVersion());
-//
-//            // get all extensions
-//            Collection<Extension<Network>> cgmesExtensions = readNetwork.getExtensions();
-//            Iterator<Extension<Network>> it = cgmesExtensions.iterator();
-//            cgmesMetadataModels = (CgmesMetadataModels) it.next();
-//            cimCharacteristics = (CimCharacteristics) it.next();
-//
-//            cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
-//            assertTrue(cgmesSvMetadataModel.isPresent());
-//            cgmesSvMetadata = cgmesSvMetadataModel.get();
-//            assertEquals(573, cgmesSvMetadata.getDescription().length());
-//            assertTrue(cgmesSvMetadata.getDescription().contains("CGMES Conformity Assessment"));
-//            assertEquals(4, cgmesSvMetadata.getVersion());
-//            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSvMetadata.getModelingAuthoritySet());
-//            assertEquals(3, cgmesSvMetadata.getDependentOn().size());
-//
-//            cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
-//            assertTrue(cgmesSshMetadataModel.isPresent());
-//            cgmesSshMetadata = cgmesSshMetadataModel.get();
-//            assertEquals(573, cgmesSshMetadata.getDescription().length());
-//            assertTrue(cgmesSshMetadata.getDescription().contains("CGMES Conformity Assessment"));
-//            assertEquals(4, cgmesSshMetadata.getVersion());
-//            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSshMetadata.getModelingAuthoritySet());
-//            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
-//
-//            assertEquals(CgmesTopologyKind.NODE_BREAKER, cimCharacteristics.getTopologyKind());
-//            assertEquals(16, cimCharacteristics.getCimVersion());
-//
-//            // modify extensions
-//            CgmesMetadataModelsAttributes cgmesMetadataModelAttributes = CgmesMetadataModelsAttributes.builder()
-//                .models(List.of(new CgmesMetadataModelAttributes(CgmesSubset.STATE_VARIABLES,
-//                        "svId", "DescriptionSv", 6, "modelingAuthoritySetSv", List.of("profileSv"),
-//                        List.of("dependentOnSv"), List.of("supersedesSv")),
-//                    new CgmesMetadataModelAttributes(CgmesSubset.STEADY_STATE_HYPOTHESIS,
-//                        "sshId", "DescriptionSsh", 7, "modelingAuthoritySetSsh", List.of("profileSsh"),
-//                        List.of("dependentOnSsh"), List.of("supersedesSsh"))))
-//                .build();
-//
-//            ((NetworkImpl) readNetwork).getResource().getAttributes().getExtensionAttributes().put(CgmesMetadataModels.NAME, cgmesMetadataModelAttributes);
-//
-//            CimCharacteristicsAttributes cimCharacteristicsAttributes = CimCharacteristicsAttributes.builder()
-//                .cimVersion(5)
-//                .cgmesTopologyKind(CgmesTopologyKind.BUS_BRANCH)
-//                .build();
-//
-//            ((NetworkImpl) readNetwork).updateResource(res -> res.getAttributes().setCimCharacteristics(cimCharacteristicsAttributes));
-//
-//            service.flush(readNetwork);
-//        }
-//
-//        try (NetworkStoreService service = createNetworkStoreService()) {
-//            Map<UUID, String> networkIds = service.getNetworkIds();
-//            assertEquals(1, networkIds.size());
-//
-//            Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
-//
-//            // get extensions by name
-//            CgmesMetadataModels cgmesMetadataModels = readNetwork.getExtensionByName("cgmesMetadataModels");
-//            Optional<CgmesMetadataModel> cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
-//            assertTrue(cgmesSvMetadataModel.isPresent());
-//            CgmesMetadataModel cgmesSvMetadata = cgmesSvMetadataModel.get();
-//            assertEquals("svId", cgmesSvMetadata.getId());
-//            assertEquals("DescriptionSv", cgmesSvMetadata.getDescription());
-//            assertEquals(6, cgmesSvMetadata.getVersion());
-//            assertEquals("modelingAuthoritySetSv", cgmesSvMetadata.getModelingAuthoritySet());
-//            assertEquals(1, cgmesSvMetadata.getProfiles().size());
-//            assertTrue(cgmesSvMetadata.getProfiles().contains("profileSv"));
-//            assertEquals(1, cgmesSvMetadata.getDependentOn().size());
-//            assertTrue(cgmesSvMetadata.getDependentOn().contains("dependentOnSv"));
-//            assertEquals(1, cgmesSvMetadata.getSupersedes().size());
-//            assertTrue(cgmesSvMetadata.getSupersedes().contains("supersedesSv"));
-//
-//            Optional<CgmesMetadataModel> cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
-//            assertTrue(cgmesSshMetadataModel.isPresent());
-//            CgmesMetadataModel cgmesSshMetadata = cgmesSshMetadataModel.get();
-//            assertEquals("sshId", cgmesSshMetadata.getId());
-//            assertEquals("DescriptionSsh", cgmesSshMetadata.getDescription());
-//            assertEquals(7, cgmesSshMetadata.getVersion());
-//            assertEquals("modelingAuthoritySetSsh", cgmesSshMetadata.getModelingAuthoritySet());
-//            assertEquals(1, cgmesSshMetadata.getProfiles().size());
-//            assertTrue(cgmesSshMetadata.getProfiles().contains("profileSsh"));
-//            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
-//            assertTrue(cgmesSshMetadata.getDependentOn().contains("dependentOnSsh"));
-//            assertEquals(1, cgmesSshMetadata.getSupersedes().size());
-//            assertTrue(cgmesSshMetadata.getSupersedes().contains("supersedesSsh"));
-//
-//            CimCharacteristics cimCharacteristics = readNetwork.getExtensionByName("cimCharacteristics");
-//            assertEquals(CgmesTopologyKind.BUS_BRANCH, cimCharacteristics.getTopologyKind());
-//            assertEquals(5, cimCharacteristics.getCimVersion());
-//
-//            // create new extensions
-//            readNetwork.newExtension(CgmesMetadataModelsAdder.class)
-//                .newModel()
-//                .setSubset(CgmesSubset.STATE_VARIABLES)
-//                .setId("svId2")
-//                .setDescription("DescriptionSv2")
-//                .setVersion(9)
-//                .setModelingAuthoritySet("modelingAuthoritySetSv2")
-//                .addProfile("profileSv2")
-//                .addDependentOn("dependentOnSv2")
-//                .addSupersedes("supersedesSv2")
-//                .add()
-//                .newModel()
-//                .setSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS)
-//                .setId("sshId2")
-//                .setDescription("DescriptionSsh2")
-//                .setVersion(3)
-//                .setModelingAuthoritySet("modelingAuthoritySetSsh2")
-//                .addProfile("profileSsh2")
-//                .addDependentOn("dependentOnSsh2")
-//                .addSupersedes("supersedesSsh2")
-//                .add()
-//                .add();
-//            readNetwork.newExtension(CimCharacteristicsAdder.class)
-//                .setTopologyKind(CgmesTopologyKind.NODE_BREAKER)
-//                .setCimVersion(6)
-//                .add();
-//            service.flush(readNetwork);
-//        }
-//
-//        try (NetworkStoreService service = createNetworkStoreService()) {
-//            Map<UUID, String> networkIds = service.getNetworkIds();
-//            assertEquals(1, networkIds.size());
-//
-//            Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
-//
-//            // get extensions by name
-//            CgmesMetadataModels cgmesMetadataModels = readNetwork.getExtensionByName("cgmesMetadataModels");
-//            Optional<CgmesMetadataModel> cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
-//            assertTrue(cgmesSvMetadataModel.isPresent());
-//            CgmesMetadataModel cgmesSvMetadata = cgmesSvMetadataModel.get();
-//            assertEquals("svId2", cgmesSvMetadata.getId());
-//            assertEquals("DescriptionSv2", cgmesSvMetadata.getDescription());
-//            assertEquals(9, cgmesSvMetadata.getVersion());
-//            assertEquals("modelingAuthoritySetSv2", cgmesSvMetadata.getModelingAuthoritySet());
-//            assertEquals(1, cgmesSvMetadata.getProfiles().size());
-//            assertTrue(cgmesSvMetadata.getProfiles().contains("profileSv2"));
-//            assertEquals(1, cgmesSvMetadata.getDependentOn().size());
-//            assertTrue(cgmesSvMetadata.getDependentOn().contains("dependentOnSv2"));
-//            assertEquals(1, cgmesSvMetadata.getSupersedes().size());
-//            assertTrue(cgmesSvMetadata.getSupersedes().contains("supersedesSv2"));
-//
-//            Optional<CgmesMetadataModel> cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
-//            assertTrue(cgmesSshMetadataModel.isPresent());
-//            CgmesMetadataModel cgmesSshMetadata = cgmesSshMetadataModel.get();
-//            assertEquals("sshId2", cgmesSshMetadata.getId());
-//            assertEquals("DescriptionSsh2", cgmesSshMetadata.getDescription());
-//            assertEquals(3, cgmesSshMetadata.getVersion());
-//            assertEquals("modelingAuthoritySetSsh2", cgmesSshMetadata.getModelingAuthoritySet());
-//            assertEquals(1, cgmesSshMetadata.getProfiles().size());
-//            assertTrue(cgmesSshMetadata.getProfiles().contains("profileSsh2"));
-//            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
-//            assertTrue(cgmesSshMetadata.getDependentOn().contains("dependentOnSsh2"));
-//            assertEquals(1, cgmesSshMetadata.getSupersedes().size());
-//            assertTrue(cgmesSshMetadata.getSupersedes().contains("supersedesSsh2"));
-//
-//            CimCharacteristics cimCharacteristics = readNetwork.getExtensionByName("cimCharacteristics");
-//            assertEquals(CgmesTopologyKind.NODE_BREAKER, cimCharacteristics.getTopologyKind());
-//            assertEquals(6, cimCharacteristics.getCimVersion());
-//        }
-//    }
+    @Test
+    public void cgmesExtensionsTest() {
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            // import new network in the store
+            Network network = service.importNetwork(CgmesConformity1Catalog.miniNodeBreaker().dataSource());
+            service.flush(network);
+        }
+
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Map<UUID, String> networkIds = service.getNetworkIds();
+            assertEquals(1, networkIds.size());
+
+            // get extensions by name
+            Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
+            CgmesMetadataModels cgmesMetadataModels = readNetwork.getExtensionByName("cgmesMetadataModels");
+            CimCharacteristics cimCharacteristics = readNetwork.getExtensionByName("cimCharacteristics");
+
+            Optional<CgmesMetadataModel> cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
+            assertTrue(cgmesSvMetadataModel.isPresent());
+            CgmesMetadataModel cgmesSvMetadata = cgmesSvMetadataModel.get();
+            assertEquals(573, cgmesSvMetadata.getDescription().length());
+            assertTrue(cgmesSvMetadata.getDescription().contains("CGMES Conformity Assessment"));
+            assertEquals(4, cgmesSvMetadata.getVersion());
+            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSvMetadata.getModelingAuthoritySet());
+            assertEquals(3, cgmesSvMetadata.getDependentOn().size());
+
+            Optional<CgmesMetadataModel> cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
+            assertTrue(cgmesSshMetadataModel.isPresent());
+            CgmesMetadataModel cgmesSshMetadata = cgmesSshMetadataModel.get();
+            assertEquals(573, cgmesSshMetadata.getDescription().length());
+            assertTrue(cgmesSshMetadata.getDescription().contains("CGMES Conformity Assessment"));
+            assertEquals(4, cgmesSshMetadata.getVersion());
+            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSshMetadata.getModelingAuthoritySet());
+            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
+
+            assertEquals(CgmesTopologyKind.NODE_BREAKER, cimCharacteristics.getTopologyKind());
+            assertEquals(16, cimCharacteristics.getCimVersion());
+
+            // get extensions by class
+            cgmesMetadataModels = readNetwork.getExtension(CgmesMetadataModels.class);
+            cimCharacteristics = readNetwork.getExtension(CimCharacteristics.class);
+            cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
+
+            assertTrue(cgmesSvMetadataModel.isPresent());
+            cgmesSvMetadata = cgmesSvMetadataModel.get();
+            assertEquals(573, cgmesSvMetadata.getDescription().length());
+            assertTrue(cgmesSvMetadata.getDescription().contains("CGMES Conformity Assessment"));
+            assertEquals(4, cgmesSvMetadata.getVersion());
+            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSvMetadata.getModelingAuthoritySet());
+            assertEquals(3, cgmesSvMetadata.getDependentOn().size());
+
+            cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
+            assertTrue(cgmesSshMetadataModel.isPresent());
+            cgmesSshMetadata = cgmesSshMetadataModel.get();
+            assertEquals(573, cgmesSshMetadata.getDescription().length());
+            assertTrue(cgmesSshMetadata.getDescription().contains("CGMES Conformity Assessment"));
+            assertEquals(4, cgmesSshMetadata.getVersion());
+            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSshMetadata.getModelingAuthoritySet());
+            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
+
+            assertEquals(CgmesTopologyKind.NODE_BREAKER, cimCharacteristics.getTopologyKind());
+            assertEquals(16, cimCharacteristics.getCimVersion());
+
+            // get all extensions
+            Collection<Extension<Network>> cgmesExtensions = readNetwork.getExtensions();
+            Iterator<Extension<Network>> it = cgmesExtensions.iterator();
+            cgmesMetadataModels = (CgmesMetadataModels) it.next();
+            cimCharacteristics = (CimCharacteristics) it.next();
+
+            cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
+            assertTrue(cgmesSvMetadataModel.isPresent());
+            cgmesSvMetadata = cgmesSvMetadataModel.get();
+            assertEquals(573, cgmesSvMetadata.getDescription().length());
+            assertTrue(cgmesSvMetadata.getDescription().contains("CGMES Conformity Assessment"));
+            assertEquals(4, cgmesSvMetadata.getVersion());
+            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSvMetadata.getModelingAuthoritySet());
+            assertEquals(3, cgmesSvMetadata.getDependentOn().size());
+
+            cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
+            assertTrue(cgmesSshMetadataModel.isPresent());
+            cgmesSshMetadata = cgmesSshMetadataModel.get();
+            assertEquals(573, cgmesSshMetadata.getDescription().length());
+            assertTrue(cgmesSshMetadata.getDescription().contains("CGMES Conformity Assessment"));
+            assertEquals(4, cgmesSshMetadata.getVersion());
+            assertEquals("http://A1.de/Planning/ENTSOE/2", cgmesSshMetadata.getModelingAuthoritySet());
+            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
+
+            assertEquals(CgmesTopologyKind.NODE_BREAKER, cimCharacteristics.getTopologyKind());
+            assertEquals(16, cimCharacteristics.getCimVersion());
+
+            // modify extensions
+            CgmesMetadataModelsAttributes cgmesMetadataModelAttributes = CgmesMetadataModelsAttributes.builder()
+                .models(List.of(new CgmesMetadataModelAttributes(CgmesSubset.STATE_VARIABLES,
+                        "svId", "DescriptionSv", 6, "modelingAuthoritySetSv", List.of("profileSv"),
+                        List.of("dependentOnSv"), List.of("supersedesSv")),
+                    new CgmesMetadataModelAttributes(CgmesSubset.STEADY_STATE_HYPOTHESIS,
+                        "sshId", "DescriptionSsh", 7, "modelingAuthoritySetSsh", List.of("profileSsh"),
+                        List.of("dependentOnSsh"), List.of("supersedesSsh"))))
+                .build();
+
+            ((NetworkImpl) readNetwork).getResource().getAttributes().getExtensionAttributes().put(CgmesMetadataModels.NAME, cgmesMetadataModelAttributes);
+
+            CimCharacteristicsAttributes cimCharacteristicsAttributes = CimCharacteristicsAttributes.builder()
+                .cimVersion(5)
+                .cgmesTopologyKind(CgmesTopologyKind.BUS_BRANCH)
+                .build();
+
+            ((NetworkImpl) readNetwork).updateResource(res -> res.getAttributes().setCimCharacteristics(cimCharacteristicsAttributes));
+
+            service.flush(readNetwork);
+        }
+
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Map<UUID, String> networkIds = service.getNetworkIds();
+            assertEquals(1, networkIds.size());
+
+            Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
+
+            // get extensions by name
+            CgmesMetadataModels cgmesMetadataModels = readNetwork.getExtensionByName("cgmesMetadataModels");
+            Optional<CgmesMetadataModel> cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
+            assertTrue(cgmesSvMetadataModel.isPresent());
+            CgmesMetadataModel cgmesSvMetadata = cgmesSvMetadataModel.get();
+            assertEquals("svId", cgmesSvMetadata.getId());
+            assertEquals("DescriptionSv", cgmesSvMetadata.getDescription());
+            assertEquals(6, cgmesSvMetadata.getVersion());
+            assertEquals("modelingAuthoritySetSv", cgmesSvMetadata.getModelingAuthoritySet());
+            assertEquals(1, cgmesSvMetadata.getProfiles().size());
+            assertTrue(cgmesSvMetadata.getProfiles().contains("profileSv"));
+            assertEquals(1, cgmesSvMetadata.getDependentOn().size());
+            assertTrue(cgmesSvMetadata.getDependentOn().contains("dependentOnSv"));
+            assertEquals(1, cgmesSvMetadata.getSupersedes().size());
+            assertTrue(cgmesSvMetadata.getSupersedes().contains("supersedesSv"));
+
+            Optional<CgmesMetadataModel> cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
+            assertTrue(cgmesSshMetadataModel.isPresent());
+            CgmesMetadataModel cgmesSshMetadata = cgmesSshMetadataModel.get();
+            assertEquals("sshId", cgmesSshMetadata.getId());
+            assertEquals("DescriptionSsh", cgmesSshMetadata.getDescription());
+            assertEquals(7, cgmesSshMetadata.getVersion());
+            assertEquals("modelingAuthoritySetSsh", cgmesSshMetadata.getModelingAuthoritySet());
+            assertEquals(1, cgmesSshMetadata.getProfiles().size());
+            assertTrue(cgmesSshMetadata.getProfiles().contains("profileSsh"));
+            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
+            assertTrue(cgmesSshMetadata.getDependentOn().contains("dependentOnSsh"));
+            assertEquals(1, cgmesSshMetadata.getSupersedes().size());
+            assertTrue(cgmesSshMetadata.getSupersedes().contains("supersedesSsh"));
+
+            CimCharacteristics cimCharacteristics = readNetwork.getExtensionByName("cimCharacteristics");
+            assertEquals(CgmesTopologyKind.BUS_BRANCH, cimCharacteristics.getTopologyKind());
+            assertEquals(5, cimCharacteristics.getCimVersion());
+
+            // create new extensions
+            readNetwork.newExtension(CgmesMetadataModelsAdder.class)
+                .newModel()
+                .setSubset(CgmesSubset.STATE_VARIABLES)
+                .setId("svId2")
+                .setDescription("DescriptionSv2")
+                .setVersion(9)
+                .setModelingAuthoritySet("modelingAuthoritySetSv2")
+                .addProfile("profileSv2")
+                .addDependentOn("dependentOnSv2")
+                .addSupersedes("supersedesSv2")
+                .add()
+                .newModel()
+                .setSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS)
+                .setId("sshId2")
+                .setDescription("DescriptionSsh2")
+                .setVersion(3)
+                .setModelingAuthoritySet("modelingAuthoritySetSsh2")
+                .addProfile("profileSsh2")
+                .addDependentOn("dependentOnSsh2")
+                .addSupersedes("supersedesSsh2")
+                .add()
+                .add();
+            readNetwork.newExtension(CimCharacteristicsAdder.class)
+                .setTopologyKind(CgmesTopologyKind.NODE_BREAKER)
+                .setCimVersion(6)
+                .add();
+            service.flush(readNetwork);
+        }
+
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Map<UUID, String> networkIds = service.getNetworkIds();
+            assertEquals(1, networkIds.size());
+
+            Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
+
+            // get extensions by name
+            CgmesMetadataModels cgmesMetadataModels = readNetwork.getExtensionByName("cgmesMetadataModels");
+            Optional<CgmesMetadataModel> cgmesSvMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STATE_VARIABLES);
+            assertTrue(cgmesSvMetadataModel.isPresent());
+            CgmesMetadataModel cgmesSvMetadata = cgmesSvMetadataModel.get();
+            assertEquals("svId2", cgmesSvMetadata.getId());
+            assertEquals("DescriptionSv2", cgmesSvMetadata.getDescription());
+            assertEquals(9, cgmesSvMetadata.getVersion());
+            assertEquals("modelingAuthoritySetSv2", cgmesSvMetadata.getModelingAuthoritySet());
+            assertEquals(1, cgmesSvMetadata.getProfiles().size());
+            assertTrue(cgmesSvMetadata.getProfiles().contains("profileSv2"));
+            assertEquals(1, cgmesSvMetadata.getDependentOn().size());
+            assertTrue(cgmesSvMetadata.getDependentOn().contains("dependentOnSv2"));
+            assertEquals(1, cgmesSvMetadata.getSupersedes().size());
+            assertTrue(cgmesSvMetadata.getSupersedes().contains("supersedesSv2"));
+
+            Optional<CgmesMetadataModel> cgmesSshMetadataModel = cgmesMetadataModels.getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS);
+            assertTrue(cgmesSshMetadataModel.isPresent());
+            CgmesMetadataModel cgmesSshMetadata = cgmesSshMetadataModel.get();
+            assertEquals("sshId2", cgmesSshMetadata.getId());
+            assertEquals("DescriptionSsh2", cgmesSshMetadata.getDescription());
+            assertEquals(3, cgmesSshMetadata.getVersion());
+            assertEquals("modelingAuthoritySetSsh2", cgmesSshMetadata.getModelingAuthoritySet());
+            assertEquals(1, cgmesSshMetadata.getProfiles().size());
+            assertTrue(cgmesSshMetadata.getProfiles().contains("profileSsh2"));
+            assertEquals(1, cgmesSshMetadata.getDependentOn().size());
+            assertTrue(cgmesSshMetadata.getDependentOn().contains("dependentOnSsh2"));
+            assertEquals(1, cgmesSshMetadata.getSupersedes().size());
+            assertTrue(cgmesSshMetadata.getSupersedes().contains("supersedesSsh2"));
+
+            CimCharacteristics cimCharacteristics = readNetwork.getExtensionByName("cimCharacteristics");
+            assertEquals(CgmesTopologyKind.NODE_BREAKER, cimCharacteristics.getTopologyKind());
+            assertEquals(6, cimCharacteristics.getCimVersion());
+        }
+    }
 
     @Test
     public void aliasesTest() {
@@ -4557,62 +4562,62 @@ public class NetworkStoreIT {
             assertEquals(1, cgmesControlArea.getBoundaries().size());
         }
     }
-        //TODO: reactivate this test in https://github.com/powsybl/powsybl-network-store-server/pull/32
-//    @Test
-//    public void baseVoltageMappingTest() {
-//        try (NetworkStoreService service = createNetworkStoreService()) {
-//            // import new network in the store
-//            Network network = service.importNetwork(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource());
-//            assertNull(network.getExtension(Object.class));
-//            assertNull(network.getExtensionByName(""));
-//            BaseVoltageMapping baseVoltageMapping = network.getExtension(BaseVoltageMapping.class);
-//            assertNotNull(baseVoltageMapping);
-//            assertEquals(7, baseVoltageMapping.getBaseVoltages().size());
-//            assertFalse(baseVoltageMapping.isBaseVoltageEmpty());
-//            var ht = baseVoltageMapping.getBaseVoltage(400.0);
-//            assertNotNull(ht);
-//            assertEquals("65dd04e792584b3b912374e35dec032e", ht.getId());
-//            assertEquals(Source.BOUNDARY, ht.getSource());
-//            assertEquals(400.0, ht.getNominalV(), .1);
-//
-//            assertFalse(baseVoltageMapping.isBaseVoltageMapped(42.0));
-//            assertNull(baseVoltageMapping.getBaseVoltage(42.0));
-//            // IGN do not remplace IGM
-//            baseVoltageMapping.addBaseVoltage(10.5, "somethingIGM", Source.IGM);
-//            assertNotEquals("somethingIGM", baseVoltageMapping.getBaseVoltage(10.5).getId());
-//            // BOUNDARY replace IGM
-//            baseVoltageMapping.addBaseVoltage(10.5, "something", Source.BOUNDARY);
-//            var bvs = BaseVoltageSourceAttribute.builder().id("something").nominalV(10.5).source(Source.BOUNDARY).build();
-//            assertEquals(bvs, baseVoltageMapping.getBaseVoltage(10.5));
-//            // BOUNDARY do not replace BOUNDARY
-//            baseVoltageMapping.addBaseVoltage(10.5, "somethingAgain", Source.BOUNDARY);
-//            assertNotEquals("somethingAgain", baseVoltageMapping.getBaseVoltage(10.5).getId());
-//            // IGM do not replace BOUNDARY
-//            baseVoltageMapping.addBaseVoltage(10.5, "somethingIGM", Source.IGM);
-//            assertNotEquals("somethingIGM", baseVoltageMapping.getBaseVoltage(10.5).getId());
-//
-//            baseVoltageMapping.addBaseVoltage(42.0, "somethingElse", Source.IGM);
-//            var ft = baseVoltageMapping.getBaseVoltage(42.0);
-//            assertEquals("somethingElse", ft.getId());
-//            assertEquals(Source.IGM, ft.getSource());
-//
-//            var baseVolatge = baseVoltageMapping.baseVoltagesByNominalVoltageMap();
-//            assertEquals(baseVoltageMapping.getBaseVoltages().size(), baseVolatge.size());
-//            service.flush(network);
-//
-//        }
-//        try (NetworkStoreService service = createNetworkStoreService()) {
-//            Map<UUID, String> networkIds = service.getNetworkIds();
-//            assertEquals(1, networkIds.size());
-//            UUID networkUuid = networkIds.keySet().iterator().next();
-//
-//            Network network = service.getNetwork(networkUuid);
-//            BaseVoltageMapping baseVoltageMapping = network.getExtensionByName("baseVoltageMapping");
-//
-//            var ft = baseVoltageMapping.getBaseVoltage(42.0);
-//            assertNotNull(ft);
-//        }
-//    }
+
+    @Test
+    public void baseVoltageMappingTest() {
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            // import new network in the store
+            Network network = service.importNetwork(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource());
+            assertNull(network.getExtension(Object.class));
+            assertNull(network.getExtensionByName(""));
+            BaseVoltageMapping baseVoltageMapping = network.getExtension(BaseVoltageMapping.class);
+            assertNotNull(baseVoltageMapping);
+            assertEquals(7, baseVoltageMapping.getBaseVoltages().size());
+            assertFalse(baseVoltageMapping.isBaseVoltageEmpty());
+            var ht = baseVoltageMapping.getBaseVoltage(400.0);
+            assertNotNull(ht);
+            assertEquals("65dd04e792584b3b912374e35dec032e", ht.getId());
+            assertEquals(Source.BOUNDARY, ht.getSource());
+            assertEquals(400.0, ht.getNominalV(), .1);
+
+            assertFalse(baseVoltageMapping.isBaseVoltageMapped(42.0));
+            assertNull(baseVoltageMapping.getBaseVoltage(42.0));
+            // IGN do not remplace IGM
+            baseVoltageMapping.addBaseVoltage(10.5, "somethingIGM", Source.IGM);
+            assertNotEquals("somethingIGM", baseVoltageMapping.getBaseVoltage(10.5).getId());
+            // BOUNDARY replace IGM
+            baseVoltageMapping.addBaseVoltage(10.5, "something", Source.BOUNDARY);
+            var bvs = BaseVoltageSourceAttribute.builder().id("something").nominalV(10.5).source(Source.BOUNDARY).build();
+            assertEquals(bvs, baseVoltageMapping.getBaseVoltage(10.5));
+            // BOUNDARY do not replace BOUNDARY
+            baseVoltageMapping.addBaseVoltage(10.5, "somethingAgain", Source.BOUNDARY);
+            assertNotEquals("somethingAgain", baseVoltageMapping.getBaseVoltage(10.5).getId());
+            // IGM do not replace BOUNDARY
+            baseVoltageMapping.addBaseVoltage(10.5, "somethingIGM", Source.IGM);
+            assertNotEquals("somethingIGM", baseVoltageMapping.getBaseVoltage(10.5).getId());
+
+            baseVoltageMapping.addBaseVoltage(42.0, "somethingElse", Source.IGM);
+            var ft = baseVoltageMapping.getBaseVoltage(42.0);
+            assertEquals("somethingElse", ft.getId());
+            assertEquals(Source.IGM, ft.getSource());
+
+            var baseVolatge = baseVoltageMapping.baseVoltagesByNominalVoltageMap();
+            assertEquals(baseVoltageMapping.getBaseVoltages().size(), baseVolatge.size());
+            service.flush(network);
+
+        }
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Map<UUID, String> networkIds = service.getNetworkIds();
+            assertEquals(1, networkIds.size());
+            UUID networkUuid = networkIds.keySet().iterator().next();
+
+            Network network = service.getNetwork(networkUuid);
+            BaseVoltageMapping baseVoltageMapping = network.getExtensionByName("baseVoltageMapping");
+
+            var ft = baseVoltageMapping.getBaseVoltage(42.0);
+            assertNotNull(ft);
+        }
+    }
 
     @Test
     public void cgmesControlAreaTieLineTest() {

--- a/network-store-integration-test/src/test/resources/network_test1_cgmes_metadata_models.xml
+++ b/network-store-integration-test/src/test/resources/network_test1_cgmes_metadata_models.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" xmlns:cmm="http://www.powsybl.org/schema/iidm/ext/cgmes_metadata_models/1_0" id="network" caseDate="2020-09-07T15:44:10.209+02:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="substation1" country="FR" tso="TSO1" geographicalTags="region1">
+        <iidm:voltageLevel id="voltageLevel1" nominalV="400.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="voltageLevel1BusbarSection1" node="0"/>
+                <iidm:busbarSection id="voltageLevel1BusbarSection2" node="1"/>
+                <iidm:switch id="voltageLevel1Breaker1" kind="BREAKER" retained="true" open="false" node1="0" node2="1"/>
+                <iidm:switch id="load1Disconnector1" kind="DISCONNECTOR" retained="false" open="false" node1="2" node2="3"/>
+                <iidm:switch id="load1Breaker1" kind="DISCONNECTOR" retained="false" open="false" node1="3" node2="0"/>
+                <iidm:switch id="generator1Disconnector1" kind="DISCONNECTOR" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="generator1Breaker1" kind="DISCONNECTOR" retained="false" open="false" node1="6" node2="1"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="generator1" energySource="NUCLEAR" minP="200.0" maxP="900.0" voltageRegulatorOn="true" targetP="900.0" targetV="380.0" node="5">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="200.0" minQ="300.0" maxQ="500.0"/>
+                    <iidm:point p="900.0" minQ="300.0" maxQ="500.0"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:load id="load1" loadType="UNDEFINED" p0="10.0" q0="3.0" node="2"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:extension id="network">
+        <cmm:cgmesMetadataModels>
+            <cmm:model id="eqId" subset="EQUIPMENT" description="EQ description" version="1" modelingAuthoritySet="http://powsybl.org">
+                <cmm:profile>http://equipment-core</cmm:profile>
+                <cmm:profile>http://equipment-operation</cmm:profile>
+                <cmm:dependentOnModel>eq-dependency1</cmm:dependentOnModel>
+                <cmm:dependentOnModel>eq-dependency2</cmm:dependentOnModel>
+            </cmm:model>
+            <cmm:model id="svId" subset="STATE_VARIABLES" description="SV description" version="1" modelingAuthoritySet="http://powsybl.org">
+                <cmm:profile>http://state-variables</cmm:profile>
+                <cmm:dependentOnModel>sv-dependency1</cmm:dependentOnModel>
+                <cmm:dependentOnModel>sv-dependency2</cmm:dependentOnModel>
+            </cmm:model>
+            <cmm:model id="sshId" subset="STEADY_STATE_HYPOTHESIS" description="SSH description" version="1" modelingAuthoritySet="http://powsybl.org">
+                <cmm:profile>http://steady-state-hypothesis</cmm:profile>
+                <cmm:dependentOnModel>ssh-dependency1</cmm:dependentOnModel>
+                <cmm:dependentOnModel>ssh-dependency2</cmm:dependentOnModel>
+                <cmm:supersedesModel>ssh-superseded1</cmm:supersedesModel>
+            </cmm:model>
+        </cmm:cgmesMetadataModels>
+    </iidm:extension>
+</iidm:network>

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -128,11 +128,15 @@ public class NetworkStoreRepository {
                             bindAttributes(resultSet, columnIndex.getValue(), columnMapping, attributes, mapper);
                             columnIndex.increment();
                         });
-                        return Optional.of(Resource.networkBuilder()
-                                .id(resultSet.getString(1)) // id is first
+                        String networkId = resultSet.getString(1); // id is first
+                        Resource<NetworkAttributes> resource = Resource.networkBuilder()
+                                .id(networkId)
                                 .variantNum(variantNum)
                                 .attributes(attributes)
-                                .build());
+                                .build();
+                        Map<OwnerInfo, Map<String, ExtensionAttributes>> extensionAttributes = extensionHandler.getExtensions(uuid, variantNum, EQUIPMENT_ID_COLUMN, networkId);
+                        extensionHandler.insertExtensionsInIdentifiables(uuid, List.of(resource), extensionAttributes);
+                        return Optional.of(resource);
                     }
                 }
                 return Optional.empty();
@@ -208,6 +212,7 @@ public class NetworkStoreRepository {
                 preparedStmt.executeBatch();
             }
         }
+        extensionHandler.insertExtensions(extensionHandler.getExtensionsFromNetworks(resources));
     }
 
     public void updateNetworks(List<Resource<NetworkAttributes>> resources) {
@@ -236,6 +241,7 @@ public class NetworkStoreRepository {
                 }
             }
         });
+        extensionHandler.updateExtensionsFromNetworks(resources);
     }
 
     public void deleteNetwork(UUID uuid) {
@@ -534,7 +540,7 @@ public class NetworkStoreRepository {
 
     private <T extends IdentifiableAttributes> Resource<T> completeResourceInfos(Resource<T> resource, UUID networkUuid, int variantNum, String equipmentId) {
         Map<OwnerInfo, Map<String, ExtensionAttributes>> extensionAttributes = extensionHandler.getExtensions(networkUuid, variantNum, EQUIPMENT_ID_COLUMN, equipmentId);
-        extensionHandler.insertExtensionsInEquipments(networkUuid, List.of((Resource<BatteryAttributes>) resource), extensionAttributes);
+        extensionHandler.insertExtensionsInIdentifiables(networkUuid, List.of(resource), extensionAttributes);
         switch (resource.getType()) {
             case GENERATOR:
                 return completeGeneratorInfos(resource, networkUuid, variantNum, equipmentId);
@@ -637,7 +643,7 @@ public class NetworkStoreRepository {
             throw new UncheckedSqlException(e);
         }
         Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensions(networkUuid, variantNum, EQUIPMENT_TYPE_COLUMN, tableMapping.getResourceType().toString());
-        extensionHandler.insertExtensionsInEquipments(networkUuid, identifiables, extensions);
+        extensionHandler.insertExtensionsInIdentifiables(networkUuid, identifiables, extensions);
         return identifiables;
     }
 
@@ -658,7 +664,7 @@ public class NetworkStoreRepository {
         }
         List<String> equipmentsIds = identifiables.stream().map(Resource::getId).toList();
         Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensionsWithInClause(networkUuid, variantNum, EQUIPMENT_ID_COLUMN, equipmentsIds);
-        extensionHandler.insertExtensionsInEquipments(networkUuid, identifiables, extensions);
+        extensionHandler.insertExtensionsInIdentifiables(networkUuid, identifiables, extensions);
         return identifiables;
     }
 
@@ -695,7 +701,7 @@ public class NetworkStoreRepository {
         } catch (SQLException e) {
             throw new UncheckedSqlException(e);
         }
-        extensionHandler.updateExtensions(networkUuid, resources);
+        extensionHandler.updateExtensionsFromEquipments(networkUuid, resources);
     }
 
     public void updateInjectionsSv(UUID networkUuid, List<Resource<InjectionSvAttributes>> resources, String tableName) {
@@ -770,7 +776,7 @@ public class NetworkStoreRepository {
                 }
             }
         });
-        extensionHandler.updateExtensions(networkUuid, resources);
+        extensionHandler.updateExtensionsFromEquipments(networkUuid, resources);
     }
 
     public void deleteIdentifiable(UUID networkUuid, int variantNum, String id, String tableName) {
@@ -784,7 +790,7 @@ public class NetworkStoreRepository {
         } catch (SQLException e) {
             throw new UncheckedSqlException(e);
         }
-        extensionHandler.deleteExtensions(networkUuid, variantNum, id);
+        extensionHandler.deleteExtensionsFromIdentifiable(networkUuid, variantNum, id);
     }
 
     // substation

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -367,6 +367,7 @@ public class NetworkStoreRepository {
             for (VariantInfos variantInfos : variantsInfoList) {
                 Resource<NetworkAttributes> sourceNetworkAttribute = getNetwork(sourceNetworkUuid, variantInfos.getNum()).orElseThrow(() -> new PowsyblException("Cannot retrieve source network attributes uuid : " + sourceNetworkUuid + ", variantId : " + variantInfos.getId()));
                 sourceNetworkAttribute.getAttributes().setUuid(targetNetworkUuid);
+                sourceNetworkAttribute.getAttributes().setExtensionAttributes(Collections.emptyMap());
                 sourceNetworkAttribute.setVariantNum(VariantUtils.findFistAvailableVariantNum(newNetworkVariants));
 
                 newNetworkVariants.add(new VariantInfos(sourceNetworkAttribute.getAttributes().getVariantId(), sourceNetworkAttribute.getVariantNum()));

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/ExtensionHandlerTest.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/ExtensionHandlerTest.java
@@ -118,7 +118,7 @@ public class ExtensionHandlerTest {
         assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("activePowerControl"));
         assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("operatingStatus"));
 
-        extensionHandler.insertExtensionsInEquipments(NETWORK_UUID, batteries, new HashMap<>());
+        extensionHandler.insertExtensionsInIdentifiables(NETWORK_UUID, batteries, new HashMap<>());
 
         assertEquals(resBatteryA.getAttributes().getExtensionAttributes(), new HashMap<>());
         assertNull(resBatteryA.getAttributes().getExtensionAttributes().get("activePowerControl"));
@@ -127,14 +127,14 @@ public class ExtensionHandlerTest {
         assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("activePowerControl"));
         assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("operatingStatus"));
 
-        extensionHandler.insertExtensionsInEquipments(NETWORK_UUID, batteries, mapA);
+        extensionHandler.insertExtensionsInIdentifiables(NETWORK_UUID, batteries, mapA);
         assertNotNull(resBatteryA.getAttributes().getExtensionAttributes().get("activePowerControl"));
         assertNotNull(resBatteryA.getAttributes().getExtensionAttributes().get("operatingStatus"));
         assertEquals(resBatteryB.getAttributes().getExtensionAttributes(), new HashMap<>());
         assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("activePowerControl"));
         assertNull(resBatteryB.getAttributes().getExtensionAttributes().get("operatingStatus"));
 
-        extensionHandler.insertExtensionsInEquipments(NETWORK_UUID, batteries, mapB);
+        extensionHandler.insertExtensionsInIdentifiables(NETWORK_UUID, batteries, mapB);
         assertNotNull(resBatteryA.getAttributes().getExtensionAttributes().get("activePowerControl"));
         assertNotNull(resBatteryA.getAttributes().getExtensionAttributes().get("operatingStatus"));
         assertNotNull(resBatteryB.getAttributes().getExtensionAttributes().get("activePowerControl"));
@@ -242,17 +242,17 @@ public class ExtensionHandlerTest {
         extensionHandler.insertExtensions(mapA);
         extensionHandler.insertExtensions(mapB);
 
-        extensionHandler.deleteExtensions(NETWORK_UUID, 0, "idBatteryA");
+        extensionHandler.deleteExtensionsFromIdentifiable(NETWORK_UUID, 0, "idBatteryA");
         Map<OwnerInfo, Map<String, ExtensionAttributes>> extensions = extensionHandler.getExtensionsWithInClause(NETWORK_UUID, 0, "equipmentId", List.of("idBatteryA", "idBatteryB"));
         assertEquals(1, extensions.size());
         Resource<BatteryAttributes> batteryB = Resource.batteryBuilder().id("idBatteryB").attributes(new BatteryAttributes()).build();
-        extensionHandler.deleteExtensions(NETWORK_UUID, List.of(batteryB));
+        extensionHandler.deleteExtensionsFromEquipments(NETWORK_UUID, List.of(batteryB));
         extensions = extensionHandler.getExtensionsWithInClause(NETWORK_UUID, 0, "equipmentId", List.of("idBatteryA", "idBatteryB"));
         assertEquals(0, extensions.size());
     }
 
     @Test
-    public void updateExtensionsTest() {
+    public void updateExtensionsFromEquipmentsTest() {
         String equipmentIdA = "idBatteryA";
 
         OwnerInfo infoBatteryA = new OwnerInfo(
@@ -281,7 +281,7 @@ public class ExtensionHandlerTest {
         BatteryAttributes batteryAttributes = new BatteryAttributes();
         batteryAttributes.setExtensionAttributes(extensionAttributesMapA);
         Resource<BatteryAttributes> batteryA = Resource.batteryBuilder().id("idBatteryA").attributes(batteryAttributes).build();
-        extensionHandler.updateExtensions(NETWORK_UUID, List.of(batteryA));
+        extensionHandler.updateExtensionsFromEquipments(NETWORK_UUID, List.of(batteryA));
         extensions = extensionHandler.getExtensions(NETWORK_UUID, 0, "equipmentId", "idBatteryA");
         extensionAttributes = extensions.get(infoBatteryA);
         activePowerControl = (ActivePowerControlAttributes) extensionAttributes.get("activePowerControl");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
This PR add support for generalized network. Before that, generalized extensions were only supported for other identifiables. 
Small refacto to distinguish between equipments/identifiables/network in ExtensionHandler to improve readability.  