### PR TITLE
add regulating terminal for converter station

### DIFF
--- a/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/VscIT.java
+++ b/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/VscIT.java
@@ -29,16 +29,4 @@ class VscIT extends AbstractVscTest {
     public void testSetterGetterInMultiVariants() {
         //FIXME remove when we fix primary key constraints violation on DB
     }
-
-    @Test
-    @Override
-    public void testRegulatingTerminal() {
-        // FIXME implement VscConverterStation.setRegulatingTerminal
-    }
-
-    @Test
-    @Override
-    public void testVscConverterStationAdder() {
-        // FIXME implement VscConverterStation.setRegulatingTerminal
-    }
 }

--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240711T130300Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240711T130300Z.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="braquartdav" id="1719233731805-1">
+        <addColumn tableName="vscconverterstation">
+            <column name="regulatingterminal" type="TEXT"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -55,3 +55,7 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20240529T130300Z.xml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/changelog_20240711T130300Z.xml
+      relativeToChangelogFile: true

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <powsybl-ws-dependencies.version>2.11.0</powsybl-ws-dependencies.version>
         <!-- FIXME: powsybl-network-store modules'version is overloaded in the dependencies section.The overloads and this property below have to be removed at next powsybl-ws-dependencies.version upgrade -->
-        <powsybl-network-store.version>1.14.0-SNAPSHOT</powsybl-network-store.version>
+        <powsybl-network-store.version>1.14.0</powsybl-network-store.version>
 
 
         <!-- FIXME : to remove when sonar version is updated on github actions -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <powsybl-ws-dependencies.version>2.11.0</powsybl-ws-dependencies.version>
         <!-- FIXME: powsybl-network-store modules'version is overloaded in the dependencies section.The overloads and this property below have to be removed at next powsybl-ws-dependencies.version upgrade -->
-        <powsybl-network-store.version>1.13.0</powsybl-network-store.version>
+        <powsybl-network-store.version>1.14.0-SNAPSHOT</powsybl-network-store.version>
 
 
         <!-- FIXME : to remove when sonar version is updated on github actions -->


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**

2 TCK tests are KO (commented) because VscConverterStation.setRegulatingTerminal is not implemented. This PR adds persistent implementation for getRegulatingTerminal/setRegulatingTerminal in VscConverterStation.



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
