### PR TITLE
Add minTargetP and maxTargetP properties set to "NaN" value.

### DIFF
--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240802T144700Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20240802T144700Z.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+<!-- The data migration is skipped if the database is not postgres because we use jsonb methods that are specific to postgres -->
+    <changeSet author="lecuyerfra" id="2b11111049277-2">
+        <sqlFile
+                dbms="postgresql"
+                path="migrationActivePowerControl_20240802T144700Z.sql"
+                relativeToChangelogFile="true"
+                splitStatements="true"
+                stripComments="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/network-store-server/src/main/resources/db/changelog/changesets/migrationActivePowerControl_20240802T144700Z.sql
+++ b/network-store-server/src/main/resources/db/changelog/changesets/migrationActivePowerControl_20240802T144700Z.sql
@@ -1,0 +1,7 @@
+UPDATE extension
+SET value_ = jsonb_set(cast(value_ as jsonb), '{minTargetP}', '"NaN"', true)
+WHERE name='activePowerControl' and value_ !~ 'minTargetP';
+
+UPDATE extension
+SET value_ = jsonb_set(cast(value_ as jsonb), '{maxTargetP}', '"NaN"', true)
+WHERE name='activePowerControl' and value_ !~ 'maxTargetP';

--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -63,3 +63,7 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20240711T130300Z.xml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/changelog_20240802T144700Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Data migration


**What is the current behavior?**
<!-- You can also link to an open issue here -->
No "NaN" value in database for the new minTargetP and maxTargetP properties in activePowerControlExtension, introduced in the last powsybl-core release 6.4.1, which can cause the loadflow to fail.


**What is the new behavior (if this is a feature change)?**
minTargetP and maxTargetP properties are added in database with "NaN" value.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
