### PR TITLE
Fix pb in tck tests for internal connections.

### DIFF
--- a/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/NodeBreakerInternalConnectionsIT.java
+++ b/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/NodeBreakerInternalConnectionsIT.java
@@ -8,7 +8,6 @@ package com.powsybl.network.store.tck;
 
 import com.powsybl.iidm.network.tck.AbstractNodeBreakerInternalConnectionsTest;
 import com.powsybl.network.store.server.NetworkStoreApplication;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
@@ -23,12 +22,4 @@ import org.springframework.test.context.junit4.SpringRunner;
     })
 @TestPropertySource(properties = { "spring.config.location=classpath:application.yaml" })
 class NodeBreakerInternalConnectionsIT extends AbstractNodeBreakerInternalConnectionsTest {
-
-    @Test
-    @Override
-    public void testTraversalInternalConnections() {
-        // FIXME getNodeInternalConnectedToStream returns some results twice
-        //  + AbstractNodeBreakerInternalConnectionsTest.findInternalConnectionsTraverseStoppingAtTerminals doesn't return the same
-        // internalConnections as the one in powsybl-core
-    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Test method testTraversalInternalConnections fails in NodeBreakerInternalConnectionsTest class with network-store implementation.
see PR in network-store-client : https://github.com/powsybl/powsybl-network-store/pull/426


**What is the new behavior (if this is a feature change)?**
 Test method testTraversalInternalConnections now succeeds


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
