### PR TITLE
remove the testMove1NbNetwork and testMove1NbNetwork overrides

### DIFF
--- a/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/LineIT.java
+++ b/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/LineIT.java
@@ -39,12 +39,12 @@ class LineIT extends AbstractLineTest {
     @Test
     @Override
     public void testMove1NbNetwork() {
-        // TODO : remove this function as soon as powsybl network store server will use powsybl network store 1.19.0 (it will correct this test)
+        // TODO : remove this function as soon as powsybl network store server will use powsybl network store 1.18.0 (it will correct this test)
     }
 
     @Test
     @Override
     public void testMove2Nb() {
-        // TODO : remove this function as soon as powsybl network store server will use powsybl network store 1.19.0 (it will correct this test)
+        // TODO : remove this function as soon as powsybl network store server will use powsybl network store 1.18.0 (it will correct this test)
     }
 }

--- a/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/LineIT.java
+++ b/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/LineIT.java
@@ -39,12 +39,12 @@ class LineIT extends AbstractLineTest {
     @Test
     @Override
     public void testMove1NbNetwork() {
-        // FIXME to investigate, TerminalNodeBreakerViewImpl/TerminalBusBreakerViewImpl.moveConnectable fails
+        // TODO : remove this function as soon as powsybl network store server will use powsybl network store 1.19.0 (it will correct this test)
     }
 
     @Test
     @Override
     public void testMove2Nb() {
-        // FIXME to investigate, TerminalNodeBreakerViewImpl/TerminalBusBreakerViewImpl.moveConnectable fails
+        // TODO : remove this function as soon as powsybl network store server will use powsybl network store 1.19.0 (it will correct this test)
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Takes in accoiunt the changes that have been made into powsybl network store here https://github.com/powsybl/powsybl-network-store/pull/447. In order to correct the testMove1NbNetwork and testMove1NbNetwork tests. Those had been overriden by empty functions. Once powsybl network store server uses the network store last version, those tests will work and the overriden empty functions may be removed.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
