### PR TITLE
Fix empty permanent limits in DB

### DIFF
--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -1958,15 +1958,17 @@ public class NetworkStoreRepository {
                 List<Map.Entry<OwnerInfo, List<PermanentLimitAttributes>>> list = new ArrayList<>(permanentLimits.entrySet());
                 for (List<Map.Entry<OwnerInfo, List<PermanentLimitAttributes>>> subUnit : Lists.partition(list, BATCH_SIZE)) {
                     for (Map.Entry<OwnerInfo, List<PermanentLimitAttributes>> entry : subUnit) {
-                        values.clear();
-                        values.add(entry.getKey().getEquipmentId());
-                        values.add(entry.getKey().getEquipmentType().toString());
-                        values.add(entry.getKey().getNetworkUuid());
-                        values.add(entry.getKey().getVariantNum());
-                        values.add(entry.getValue().stream()
-                                .map(PermanentLimitSqlData::of).toList());
-                        bindValues(preparedStmt, values, mapper);
-                        preparedStmt.addBatch();
+                        if (!entry.getValue().isEmpty()) {
+                            values.clear();
+                            values.add(entry.getKey().getEquipmentId());
+                            values.add(entry.getKey().getEquipmentType().toString());
+                            values.add(entry.getKey().getNetworkUuid());
+                            values.add(entry.getKey().getVariantNum());
+                            values.add(entry.getValue().stream()
+                                    .map(PermanentLimitSqlData::of).toList());
+                            bindValues(preparedStmt, values, mapper);
+                            preparedStmt.addBatch();
+                        }
                     }
                     preparedStmt.executeBatch();
                 }

--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20250131T140000Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20250131T140000Z.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="2986875648500-1" author="bouhoursant">
+        <delete tableName="permanentlimits">
+            <where>permanentlimits = '[]'</where>
+        </delete>
+    </changeSet>
+</databaseChangeLog>

--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -100,6 +100,10 @@ databaseChangeLog:
       file: changesets/changelog_20241223T130000Z.xml
       relativeToChangelogFile: true
 
+  - include:
+      file: changesets/changelog_20250131T140000Z.xml
+      relativeToChangelogFile: true
+
 # Deletion of V2.11 limits tables. To be added before tag v2.14.0 is deployed
 #  - include:
 #      file: changesets/changelog_20250114T140000Z.xml


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Without this PR, lines created without limits add permanent limits with empty data in the DB. 
Similarly to temporary limits (which do not have this behavior), we filter empty limit to avoid adding them in DB.

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
See above


**What is the new behavior (if this is a feature change)?**
See above


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No