### PR TITLE
fix test broken when upgrading network-store-version

### DIFF
--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -199,12 +199,10 @@ class NetworkStoreIT {
             assertNull(voltageLevel1.getNodeBreakerView().getTerminal(4));
             List<Integer> traversedNodes = new ArrayList<>();
             voltageLevel1.getNodeBreakerView().traverse(2, (node1, sw, node2) -> {
-                if (!traversedNodes.contains(node1)) {
-                    traversedNodes.add(node1);
-                }
+                traversedNodes.add(node1);
                 return TraverseResult.CONTINUE;
             });
-            assertEquals(Arrays.asList(2, 3, 0, 1, 6, 5), traversedNodes);
+            assertEquals(Arrays.asList(2, 3, 0, 1, 6), traversedNodes);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,7 @@
 
     <properties>
         <sirocco.version>1.0</sirocco.version>
-        <powsybl-ws-dependencies.version>2.17.0</powsybl-ws-dependencies.version>
-
+        <powsybl-ws-dependencies.version>2.18.0</powsybl-ws-dependencies.version>
         <!-- FIXME : to remove when sonar version is updated on github actions -->
         <!-- https://community.sonarsource.com/t/stackoverflowerror-at-defaultinputcomponent-equals/20324 -->
         <!-- The versions are very different from this post. But the fix works again. Maybe a similar problem in sonar code -->


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [ ] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
it reverts https://github.com/powsybl/powsybl-network-store-server/pull/89
