### PR TITLE
Fix typo in tap changer steps query

### DIFF
--- a/network-store-server/src/main/java/com/powsybl/network/store/server/QueryCatalog.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/QueryCatalog.java
@@ -654,7 +654,7 @@ public final class QueryCatalog {
             "where " +
             NETWORK_UUID_COLUMN + " = ?" + " and " +
             VARIANT_NUM_COLUMN + " = ? and " +
-            columnNameForWhereClause + " = ?" + "order by " + INDEX_COLUMN;
+            columnNameForWhereClause + " = ? order by " + INDEX_COLUMN;
     }
 
     public static String buildTapChangerStepWithInClauseQuery(String columnNameForInClause, int numberOfValues) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix typo in query. The query is not working anymore with higher versions of Postgres (>= 17).

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Following error is thrown by Postgres (>=17):
org.postgresql.util.PSQLException: ERROR: trailing junk after parameter at or near "$3order"


**What is the new behavior (if this is a feature change)?**
No error should be thrown.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No