### PR TITLE
v214 steps migration: apply changeset and clean 214 code

### DIFF
--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -120,10 +120,9 @@ databaseChangeLog:
       file: changesets/changelog_20250130T140000Z.xml
       relativeToChangelogFile: true
 
-# Migration of V2.14 tap changer steps. To be added before tag v2.15.0 is deployed
-#  - include:
-#      file: changesets/changelog_20250130T150000Z.xml
-#      relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20250130T150000Z.xml
+      relativeToChangelogFile: true
 
 # Deletion of V2.14 tap changer steps. To be added before tag v2.x.0 is deployed
 #  - include:

--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -124,7 +124,7 @@ databaseChangeLog:
       file: changesets/changelog_20250130T150000Z.xml
       relativeToChangelogFile: true
 
-# Deletion of V2.14 tap changer steps. To be added before tag v2.x.0 is deployed
+# Deletion of V2.14 tap changer steps. To be added before tag v2.17.0 is deployed
 #  - include:
 #      file: changesets/changelog_20250130T160000Z.xml
 #      relativeToChangelogFile: true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
db migration progression


**What is the new behavior (if this is a feature change)?**
to migrate the tap changer steps, the new tables are already created, now we remove the old code, steps are migrated and only the new tables are used. The old tables will be removed in the last part of the migration. 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


