### PR TITLE
Improve delete extensions from identifiables performance

### DIFF
--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -3901,7 +3901,7 @@ public class NetworkStoreRepository {
     public void removeExtensionAttributes(UUID networkId, int variantNum, String identifiableId, String extensionName) {
         try (var connection = dataSource.getConnection()) {
             boolean isPartialVariant = !getNetworkAttributes(connection, networkId, variantNum).isFullVariant();
-            extensionHandler.deleteAndTombstoneExtensions(connection, networkId, variantNum, Map.of(identifiableId, Set.of(extensionName)), isPartialVariant);
+            extensionHandler.deleteAndTombstoneExtensions(connection, networkId, variantNum, Map.of(extensionName, Set.of(identifiableId)), isPartialVariant);
         } catch (SQLException e) {
             throw new UncheckedSqlException(e);
         }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/QueryExtensionCatalog.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/QueryExtensionCatalog.java
@@ -99,26 +99,17 @@ public final class QueryExtensionCatalog {
                 NETWORK_UUID_COLUMN + " = ?";
     }
 
-    public static String buildDeleteExtensionsVariantByIdentifiableIdAndExtensionsNameINQuery(int numberOfValues) {
-        if (numberOfValues < 1) {
+    public static String buildDeleteExtensionsVariantByExtensionsNameAndIdentifiableIdsINQuery(int numberOfIds) {
+        if (numberOfIds < 1) {
             throw new IllegalArgumentException(MINIMAL_VALUE_REQUIREMENT_ERROR);
         }
 
-        StringBuilder sql = new StringBuilder()
-                .append("delete from ").append(EXTENSION_TABLE)
-                .append(" where ")
-                .append(NETWORK_UUID_COLUMN).append(" = ? and ")
-                .append(VARIANT_NUM_COLUMN).append(" = ? and (");
-
-        for (int i = 0; i < numberOfValues; i++) {
-            if (i > 0) {
-                sql.append(" or ");
-            }
-            sql.append("(").append(EQUIPMENT_ID_COLUMN).append(" = ? and ").append("name").append(" = ?)");
-        }
-        sql.append(")");
-
-        return sql.toString();
+        return "delete from " + EXTENSION_TABLE +
+                " where " + NETWORK_UUID_COLUMN + " = ? " +
+                "and " + VARIANT_NUM_COLUMN + " = ? " +
+                "and name = ? " +
+                "and " + EQUIPMENT_ID_COLUMN + " in (" +
+                "?, ".repeat(numberOfIds - 1) + "?)";
     }
 
     // Tombstoned extensions

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/ExtensionHandlerTest.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/ExtensionHandlerTest.java
@@ -193,7 +193,9 @@ class ExtensionHandlerTest {
 
         Map<String, ExtensionAttributes> extensions = extensionHandler.getAllExtensionsAttributesByIdentifiableIdForVariant(connection, NETWORK_UUID, 0, batteryId1);
         assertEquals(2, extensions.size());
-        extensionHandler.deleteExtensionsFromIdentifiables(connection, NETWORK_UUID, 0, Map.of(batteryId1, Set.of("activePowerControl")));
+        extensionHandler.deleteExtensionsFromIdentifiables(connection, NETWORK_UUID, 0, Map.of(
+                "activePowerControl", Set.of(batteryId1)
+        ));
         extensions = extensionHandler.getAllExtensionsAttributesByIdentifiableIdForVariant(connection, NETWORK_UUID, 0, batteryId1);
         assertEquals(1, extensions.size());
         assertFalse(extensions.containsKey("activePowerControl"));
@@ -203,7 +205,10 @@ class ExtensionHandlerTest {
         extensions = extensionHandler.getAllExtensionsAttributesByIdentifiableIdForVariant(connection, NETWORK_UUID, 0, batteryId1);
         assertEquals(0, extensions.size());
 
-        extensionHandler.deleteExtensionsFromIdentifiables(connection, NETWORK_UUID, 0, Map.of(batteryId2, Set.of("activePowerControl", "operatingStatus")));
+        extensionHandler.deleteExtensionsFromIdentifiables(connection, NETWORK_UUID, 0, Map.of(
+                "activePowerControl", Set.of(batteryId2),
+                "operatingStatus", Set.of(batteryId2)
+        ));
         extensions = extensionHandler.getAllExtensionsAttributesByIdentifiableIdForVariant(connection, NETWORK_UUID, 0, batteryId2);
         assertEquals(0, extensions.size());
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Improve performance of delete extensions from identifiables. 


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In the current behavior, we delete extensions from identifiables using a `delete (extensionName1, equipmentId1) OR (extensionName1, equipmentId2) OR ...`
This is not efficient and takes around 800ms. Postgres handle this request in ~5ms but there is an overhead somewhere that I could not identify. This is visible if one put a timer around `executeUpdate()` in `deleteExtensionsFromIdentifiables`.


**What is the new behavior (if this is a feature change)?**
We delete extensions from identifiables by grouping by extension names. One batch is done for each extensionName. The sql is like: `delete where extensionName = extensionName1 and id in (equipmentId1, equipmentId2, ....`
This is efficient and takes around 10ms. Updating 1000 generators is again around 200ms instead of 1000ms.