### PR TITLE
Use CI status badge from main instead of any PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PowSyBl Network Store Server
 
-[![Actions Status](https://github.com/powsybl/powsybl-network-store-server/workflows/CI/badge.svg)](https://github.com/powsybl/powsybl-network-store-server/actions)
+[![Actions Status](https://github.com/powsybl/powsybl-network-store-server/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/powsybl/powsybl-network-store-server/actions)
 [![Coverage Status](https://sonarcloud.io/api/project_badges/measure?project=com.powsybl%3Apowsybl-network-store-server&metric=coverage)](https://sonarcloud.io/component_measures?id=com.powsybl%3Apowsybl-network-store-server&metric=coverage)
 [![MPL-2.0 License](https://img.shields.io/badge/license-MPL_2.0-blue.svg)](https://www.mozilla.org/en-US/MPL/2.0/)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/powsybl)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The CI badge on the landing page shows a failure when any PR fails


**What is the new behavior (if this is a feature change)?**
The CI badge on the landing page shows the status of the last CI of main

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No