### PR TITLE
Bump hikari's max-pool-size from 10 to 20

### DIFF
--- a/network-store-server/src/main/resources/config/application.yaml
+++ b/network-store-server/src/main/resources/config/application.yaml
@@ -2,10 +2,16 @@ spring:
   application:
     name: network-store-server
   datasource:
-    # By default powsybl-commons-ws sets this to 1, reset it to the default 10
-    # for network-store because it is critical
+    # Network-store is critical in our system, raise some default limits
     hikari:
+      # By default powsybl-commons-ws sets this to 1, reset it to hikari's default
       minimum-idle: 10
+      # By default hikari sets this to 10, set it to 20 as we have observed the pool
+      # grow a little bit over 10 under load (ALL_COLLECTION_NEEDED_FOR_BUS_VIEW and updates).
+      # This is especially true with uneven request load balancing among replicas,
+      # or maybe just random transient significative unbalance of longer/shorter requests.
+      # NOTE: This parameter must be taken into account to size the Xmx correctly.
+      maximum-pool-size: 20
 
 powsybl-ws:
   database:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
hikari max-pool-size 10


**What is the new behavior (if this is a feature change)?**
hikari max-pool-size 20



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Under load the pool was observed to grow to 12 in some replicas