### PR TITLE
Batch get selected operational limits groups

### DIFF
--- a/network-store-server/src/main/java/com/powsybl/network/store/server/LimitsHandler.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/LimitsHandler.java
@@ -405,25 +405,13 @@ public class LimitsHandler {
             int conditionCount = subSelectedOperationalLimitsGroups.stream()
                     .mapToInt(identifiers ->
                             (identifiers.operationalLimitsGroupId1() != null ? 1 : 0) +
-                                    (identifiers.operationalLimitsGroupId2() != null ? 1 : 0))
+                            (identifiers.operationalLimitsGroupId2() != null ? 1 : 0))
                     .sum();
 
             try (var preparedStmt = connection.prepareStatement(QueryLimitsCatalog.buildSelectedOperationalLimitsGroupINQuery(conditionCount))) {
                 preparedStmt.setObject(1, networkId);
                 preparedStmt.setInt(2, variantNum);
-                int paramIndex = 3;
-                for (SelectedOperationalLimitsGroupIdentifiers identifiers : subSelectedOperationalLimitsGroups) {
-                    if (identifiers.operationalLimitsGroupId1() != null) {
-                        preparedStmt.setString(paramIndex++, identifiers.branchId());
-                        preparedStmt.setString(paramIndex++, identifiers.operationalLimitsGroupId1());
-                        preparedStmt.setInt(paramIndex++, 1);
-                    }
-                    if (identifiers.operationalLimitsGroupId2() != null) {
-                        preparedStmt.setString(paramIndex++, identifiers.branchId());
-                        preparedStmt.setString(paramIndex++, identifiers.operationalLimitsGroupId2());
-                        preparedStmt.setInt(paramIndex++, 2);
-                    }
-                }
+                setSelectedOperationalLimitsGroupParameters(preparedStmt, subSelectedOperationalLimitsGroups);
 
                 Map<OperationalLimitsGroupOwnerInfo, OperationalLimitsGroupAttributes> batchResults = innerGetOperationalLimitsGroups(preparedStmt, variantNumOverride);
                 results.putAll(batchResults);
@@ -432,6 +420,22 @@ public class LimitsHandler {
             }
         }
         return results;
+    }
+
+    private static void setSelectedOperationalLimitsGroupParameters(PreparedStatement preparedStmt, List<SelectedOperationalLimitsGroupIdentifiers> selectedOperationalLimitsGroups) throws SQLException {
+        int paramIndex = 3;
+        for (SelectedOperationalLimitsGroupIdentifiers identifiers : selectedOperationalLimitsGroups) {
+            if (identifiers.operationalLimitsGroupId1() != null) {
+                preparedStmt.setString(paramIndex++, identifiers.branchId());
+                preparedStmt.setString(paramIndex++, identifiers.operationalLimitsGroupId1());
+                preparedStmt.setInt(paramIndex++, 1);
+            }
+            if (identifiers.operationalLimitsGroupId2() != null) {
+                preparedStmt.setString(paramIndex++, identifiers.branchId());
+                preparedStmt.setString(paramIndex++, identifiers.operationalLimitsGroupId2());
+                preparedStmt.setInt(paramIndex++, 2);
+            }
+        }
     }
 
     private Map<OwnerInfo, SelectedOperationalLimitsGroupIdentifiers> getSelectedOperationalLimitsGroupIds(UUID networkId, int variantNum, ResourceType type) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Batch selected operational limits group query


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If > 20000 operational limits group are requested, we hit the IN clause limit (64k)


**What is the new behavior (if this is a feature change)?**
Batched in small IN clauses 1000 by 1000. I tested that there was no performance overhead.