### PR TITLE
RestResponseEntityExceptionHandler: make it more like other projects execptionhandler

### DIFF
--- a/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/RestResponseEntityExceptionHandler.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/RestResponseEntityExceptionHandler.java
@@ -18,8 +18,6 @@ import org.springframework.http.HttpStatus.Series;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import com.powsybl.network.store.model.ErrorObject;
 import com.powsybl.network.store.model.TopLevelError;
@@ -28,7 +26,7 @@ import com.powsybl.network.store.model.TopLevelError;
  * @author Jon Harper <jon.harper at rte-france.com>
  */
 @ControllerAdvice
-public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+public class RestResponseEntityExceptionHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RestResponseEntityExceptionHandler.class);
 
@@ -58,7 +56,6 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
         }
     }
 
-    @ResponseBody
     @ExceptionHandler(JsonApiErrorResponseException.class)
     public ResponseEntity<TopLevelError> handleControllerException(HttpServletRequest request, JsonApiErrorResponseException ex) {
         if (LOGGER.isErrorEnabled()) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
chore


**What is the current behavior?**
<!-- You can also link to an open issue here -->
code not homogeneous with others projects e.g. https://github.com/powsybl/powsybl-network-conversion-server/blob/main/src/main/java/com/powsybl/network/conversion/server/RestResponseEntityExceptionHandler.java


**What is the new behavior (if this is a feature change)?**
less differences


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
remove unneded "extends ResponseEntityExceptionHandler" and @ResponseBody
