### PR TITLE
remove old limits tables

### DIFF
--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20250929T160000Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20250929T160000Z.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="2986875648456-1" author="lesoteti">
+        <dropTable tableName="permanentlimits"/>
+        <dropTable tableName="temporarylimits"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -139,3 +139,7 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20250130T160000Z.xml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/changelog_20250929T160000Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
tables permanentlimits and temporarylimits tables were replaced by operationallimitsgroup but not removed, so we will remove them in this pr