### PR TITLE
Add observation methods for extensions and limits in NetworkStore

### DIFF
--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreController.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreController.java
@@ -1559,7 +1559,9 @@ public class NetworkStoreController {
     public ResponseEntity<Map<String, Map<String, ExtensionAttributes>>> getAllExtensionsAttributesByResourceType(@Parameter(description = "Network ID", required = true) @PathVariable("networkId") UUID networkId,
                                                                                                   @Parameter(description = "Variant number", required = true) @PathVariable("variantNum") int variantNum,
                                                                                                   @Parameter(description = "Resource type", required = true) @PathVariable("type") ResourceType type) {
-        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(repository.getAllExtensionsAttributesByResourceType(networkId, variantNum, type));
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(
+            networkStoreObserver.observeExtensions("get.all.extensions", type,
+                () -> repository.getAllExtensionsAttributesByResourceType(networkId, variantNum, type)));
     }
 
     @DeleteMapping(value = "{networkId}/{variantNum}/identifiables/{identifiableId}/extensions/{extensionName}")
@@ -1603,7 +1605,8 @@ public class NetworkStoreController {
                                                                                                                      @Parameter(description = "Variant number", required = true) @PathVariable("variantNum") int variantNum,
                                                                                                                      @Parameter(description = "Resource type", required = true) @PathVariable("resourceType") ResourceType type) {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(
-            repository.getAllOperationalLimitsGroupAttributesByResourceType(networkId, variantNum, type));
+            networkStoreObserver.observeLimitsGroups("get.all.limits.groups", type,
+                () -> repository.getAllOperationalLimitsGroupAttributesByResourceType(networkId, variantNum, type)));
     }
 
     @GetMapping(value = "{networkId}/{variantNum}/branch/types/{resourceType}/operationalLimitsGroup/selected")
@@ -1613,7 +1616,8 @@ public class NetworkStoreController {
                                                                                                                                                                       @Parameter(description = "Variant number", required = true) @PathVariable("variantNum") int variantNum,
                                                                                                                                                                       @Parameter(description = "Resource type", required = true) @PathVariable("resourceType") ResourceType type) {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(
-            repository.getAllSelectedOperationalLimitsGroupAttributesByResourceType(networkId, variantNum, type));
+            networkStoreObserver.observeLimitsGroups("get.all.limits.groups.selected", type,
+                () -> repository.getAllSelectedOperationalLimitsGroupAttributesByResourceType(networkId, variantNum, type)));
     }
 
     @GetMapping(value = "{networkId}/{variantNum}/branch/{branchId}/types/{resourceType}/side/{side}/operationalLimitsGroup")

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreObserver.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreObserver.java
@@ -19,6 +19,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -113,6 +114,29 @@ public class NetworkStoreObserver {
                     recordPerResourceMetric(observation, name, resourceType, results.size());
                     return results;
                 });
+    }
+
+    public <K, K2, V, E extends Throwable> Map<K, Map<K2, V>> observeExtensions(String name, ResourceType resourceType, Observation.CheckedCallable<Map<K, Map<K2, V>>, E> callable) throws E {
+        Observation observation = createObservation(name, resourceType);
+        return observation
+            .observeChecked(() -> {
+                Map<K, Map<K2, V>> results = callable.call();
+                int size = results.values().stream().mapToInt(Map::size).sum();
+                recordPerResourceMetric(observation, name, resourceType, size);
+                return results;
+            });
+    }
+
+    public <K, K2, K3, V, E extends Throwable> Map<K, Map<K2, Map<K3, V>>> observeLimitsGroups(String name, ResourceType resourceType, Observation.CheckedCallable<Map<K, Map<K2, Map<K3, V>>>, E> callable) throws E {
+        Observation observation = createObservation(name, resourceType);
+        return observation
+            .observeChecked(() -> {
+                Map<K, Map<K2, Map<K3, V>>> results = callable.call();
+                int size = results.values().stream()
+                    .mapToInt(m -> m.values().stream().mapToInt(Map::size).sum()).sum();
+                recordPerResourceMetric(observation, name, resourceType, size);
+                return results;
+            });
     }
 
     public <T extends Attributes, E extends Throwable> Optional<Resource<T>> observeOne(String name, Observation.CheckedCallable<Optional<Resource<T>>, E> callable) throws E {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This PR introduces new metrics.

**What is the current behavior?**
Currently, the `NetworkStoreObserver` and `NetworkStoreController` lack methods to observe extensions and limits.

**What is the new behavior (if this is a feature change)?**
New observation methods for extensions and limits groups have been added to `NetworkStoreObserver` and integrated into `NetworkStoreController`.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
None.


**Other information**:
None.