### PR TITLE
Add missing migration on calculated buses

### DIFF
--- a/network-store-server/src/main/resources/db/changelog/changesets/changelog_20260505T094635Z.xml
+++ b/network-store-server/src/main/resources/db/changelog/changesets/changelog_20260505T094635Z.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1777974395000-1" author="bouhoursant">
+        <sql>
+            UPDATE voltagelevel
+            SET calculatedbusesforbusview = REPLACE(calculatedbusesforbusview, '"connectableType":"DANGLING_LINE"', '"connectableType":"BOUNDARY_LINE"')
+            WHERE calculatedbusesforbusview LIKE '%"connectableType":"DANGLING_LINE"%';
+
+            UPDATE voltagelevel
+            SET calculatedbusesforbusbreakerview = REPLACE(calculatedbusesforbusbreakerview, '"connectableType":"DANGLING_LINE"', '"connectableType":"BOUNDARY_LINE"')
+            WHERE calculatedbusesforbusbreakerview LIKE '%"connectableType":"DANGLING_LINE"%';
+        </sql>
+        <rollback>
+            <sql>
+                UPDATE voltagelevel
+                SET calculatedbusesforbusview = REPLACE(calculatedbusesforbusview, '"connectableType":"BOUNDARY_LINE"', '"connectableType":"DANGLING_LINE"')
+                WHERE calculatedbusesforbusview LIKE '%"connectableType":"BOUNDARY_LINE"%';
+
+                UPDATE voltagelevel
+                SET calculatedbusesforbusbreakerview = REPLACE(calculatedbusesforbusbreakerview, '"connectableType":"BOUNDARY_LINE"', '"connectableType":"DANGLING_LINE"')
+                WHERE calculatedbusesforbusbreakerview LIKE '%"connectableType":"BOUNDARY_LINE"%';
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/network-store-server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -155,3 +155,7 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20260316T100000Z.xml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/changelog_20260505T094635Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Can't read voltage level because connectable type "DANGLING_LINE" does not exist anymore in the calculated bus view.  


**What is the new behavior (if this is a feature change)?**
Voltage level connectable type "DANGLING_LINE" is migrated to "BOUNDARY_LINE".  
Voltage level can be read even if a boundary line is in the network.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
